### PR TITLE
pc - fix an error with changing package name that led to the appearance of jacoco test gaps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <java.version>21</java.version>
     <mainClass>edu.ucsb.cs156.dining.ExampleApplication</mainClass>
     <app.package>edu.ucsb.cs156.dining</app.package>
-    <app.packagePath>edu/ucsb/cs156/example</app.packagePath>
+    <app.packagePath>edu/ucsb/cs156/dining</app.packagePath>
     <targetClasses>${targetClasses:edu.ucsb.cs156.*}</targetClasses>
     <!-- https://mvnrepository.com/artifact/com.github.eirslett/frontend-maven-plugin -->
     <frontend-maven-plugin.version>1.15.1</frontend-maven-plugin.version>
@@ -229,7 +229,7 @@
             <exclude>**/${app.packagePath}/services/CurrentUserServiceImpl.*</exclude>
             <exclude>**/${app.packagePath}/services/GrantedAuthoritiesService.*</exclude>
             <exclude>**/${app.packagePath}/ExampleApplication.*</exclude>
-            <exclude>**/edu/ucsb/cs156/example/services/wiremock/*</exclude>
+            <exclude>**/${app.packagePath}/services/wiremock/*</exclude>
           </excludes>
         </configuration>
         <executions>


### PR DESCRIPTION
We forgot to change 'example' to 'dining' in a couple of spots. This fixes that.


