### PR TITLE
Test Corrections to Kill CurrentUser Mutations

### DIFF
--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -226,20 +226,19 @@ describe("utils/currentUser tests", () => {
     test("hasRole falls back correctly with various data missing", async () => {
       expect(hasRole(null, "ROLE_USER")).toBeFalsy();
       expect(hasRole({}, "ROLE_USER")).toBeFalsy();
-      expect(hasRole({ currentUser: null }, "ROLE_USER")).toBeFalsy();
-      expect(hasRole({ currentUser: { data: null } }, "ROLE_USER")).toBeFalsy();
+      expect(hasRole({ data: null } , "ROLE_USER")).toBeFalsy();
       expect(
-        hasRole({ currentUser: { data: { root: null } } }, "ROLE_USER"),
+        hasRole({ data: { root: null } }, "ROLE_USER"),
       ).toBeFalsy();
       expect(
         hasRole(
-          { currentUser: { data: { root: { rolesList: null } } } },
+          { data: { root: { rolesList: null } } },
           "ROLE_USER",
         ),
       ).toBeFalsy();
       expect(
         hasRole(
-          { currentUser: { data: { root: { rolesList: [] } } } },
+           { data: { root: { rolesList: [] } } },
           "ROLE_USER",
         ),
       ).toBeFalsy();

--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -243,5 +243,8 @@ describe("utils/currentUser tests", () => {
         ),
       ).toBeFalsy();
     });
+      expect(
+          hasRole({root: {rolesList: null}})
+      ).toBeFalsy();
   });
 });

--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -226,25 +226,15 @@ describe("utils/currentUser tests", () => {
     test("hasRole falls back correctly with various data missing", async () => {
       expect(hasRole(null, "ROLE_USER")).toBeFalsy();
       expect(hasRole({}, "ROLE_USER")).toBeFalsy();
-      expect(hasRole({ data: null } , "ROLE_USER")).toBeFalsy();
+      expect(hasRole({ data: null }, "ROLE_USER")).toBeFalsy();
+      expect(hasRole({ data: { root: null } }, "ROLE_USER")).toBeFalsy();
       expect(
-        hasRole({ data: { root: null } }, "ROLE_USER"),
+        hasRole({ data: { root: { rolesList: null } } }, "ROLE_USER"),
       ).toBeFalsy();
       expect(
-        hasRole(
-          { data: { root: { rolesList: null } } },
-          "ROLE_USER",
-        ),
-      ).toBeFalsy();
-      expect(
-        hasRole(
-           { data: { root: { rolesList: [] } } },
-          "ROLE_USER",
-        ),
+        hasRole({ data: { root: { rolesList: [] } } }, "ROLE_USER"),
       ).toBeFalsy();
     });
-      expect(
-          hasRole({root: {rolesList: null}})
-      ).toBeFalsy();
+    expect(hasRole({ root: { rolesList: null } })).toBeFalsy();
   });
 });


### PR DESCRIPTION
In this PR, we rework a currentUser.js test to kill any missing mutations. Specifically, a few optional chaining mutations appeared in the `hasRole` method in `currentUser.js`. As a result, we revise the hierarchy on one of the tests.

This has 100% coverage and mutation coverage.