### PR TITLE
Adding the commons list to the home page

### DIFF
--- a/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
+++ b/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
@@ -1,11 +1,14 @@
 import React from "react";
 import OurTable from "main/components/OurTable";
+import { Link } from "react-router-dom";
 
 export default function DiningCommonsTable({ commons }) {
+  const testid = "DiningCommonsTable";
   const columns = [
     {
       Header: "Code",
       accessor: "code", // accessor is the "key" in the data
+      Cell: ({ value }) => <Link to={`/diningcommons/${value}`}>{value}</Link>,
     },
     {
       Header: "Name",
@@ -37,8 +40,6 @@ export default function DiningCommonsTable({ commons }) {
       accessor: "longitude",
     },
   ];
-
-  const testid = "DiningCommonsTable";
 
   const displayedColumns = columns;
 

--- a/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
+++ b/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
@@ -8,7 +8,9 @@ export default function DiningCommonsTable({ commons, date }) {
     {
       Header: "Code",
       accessor: "code", // accessor is the "key" in the data
-      Cell: ({ value }) => <Link to={`/diningcommons/${date}/${value}`}>{value}</Link>,
+      Cell: ({ value }) => (
+        <Link to={`/diningcommons/${date}/${value}`}>{value}</Link>
+      ),
     },
     {
       Header: "Name",

--- a/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
+++ b/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
@@ -2,13 +2,13 @@ import React from "react";
 import OurTable from "main/components/OurTable";
 import { Link } from "react-router-dom";
 
-export default function DiningCommonsTable({ commons }) {
+export default function DiningCommonsTable({ commons, date }) {
   const testid = "DiningCommonsTable";
   const columns = [
     {
       Header: "Code",
       accessor: "code", // accessor is the "key" in the data
-      Cell: ({ value }) => <Link to={`/diningcommons/${value}`}>{value}</Link>,
+      Cell: ({ value }) => <Link to={`/diningcommons/${date}/${value}`}>{value}</Link>,
     },
     {
       Header: "Name",

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -1,15 +1,17 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useBackend } from "../utils/useBackend";
+import DiningCommonsTable from "../components/DiningCommons/DiningCommonsTable";
 
 export default function HomePage() {
+  const { data } = useBackend(
+    [`/api/dining/all`],
+    { method: "GET", url: "/api/dining/all" },
+    [],
+  );
   return (
     <BasicLayout>
-      <div className="pt-2">
-        <h1>Hello, world!</h1>
-        <p>
-          This is a webapp containing a bunch of different Spring Boot/React
-          examples.
-        </p>
-      </div>
+      <h1>Dining Commons</h1>
+      <DiningCommonsTable commons={data} />
     </BasicLayout>
   );
 }

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -4,6 +4,7 @@ import DiningCommonsTable from "../components/DiningCommons/DiningCommonsTable";
 
 export default function HomePage() {
   const { data } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
     [`/api/dining/all`],
     { method: "GET", url: "/api/dining/all" },
     [],

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -9,10 +9,13 @@ export default function HomePage() {
     { method: "GET", url: "/api/dining/all" },
     [],
   );
+
+  const date = new Date().toISOString().split("T")[0];
+
   return (
     <BasicLayout>
       <h1>Dining Commons</h1>
-      <DiningCommonsTable commons={data} />
+      <DiningCommonsTable commons={data} date={date} />
     </BasicLayout>
   );
 }

--- a/frontend/src/stories/components/DiningCommons/DiningCommons.stories.js
+++ b/frontend/src/stories/components/DiningCommons/DiningCommons.stories.js
@@ -12,22 +12,22 @@ const Template = (args) => {
 };
 
 export const Empty = Template.bind({});
-const date = new Date('2025-03-11').toISOString().split('T')[0];
+const date = new Date("2025-03-11").toISOString().split("T")[0];
 
 Empty.args = {
   commons: [],
-  date: date
+  date: date,
 };
 
 export const ThreeItemsOrdinaryUser = Template.bind({});
 
 ThreeItemsOrdinaryUser.args = {
   commons: diningCommonsFixtures.fourCommons,
-  date: date
+  date: date,
 };
 
 export const ThreeItemsAdminUser = Template.bind({});
 ThreeItemsAdminUser.args = {
   commons: diningCommonsFixtures.fourCommons,
-  date: date
+  date: date,
 };

--- a/frontend/src/stories/components/DiningCommons/DiningCommons.stories.js
+++ b/frontend/src/stories/components/DiningCommons/DiningCommons.stories.js
@@ -12,18 +12,22 @@ const Template = (args) => {
 };
 
 export const Empty = Template.bind({});
+const date = new Date('2025-03-11').toISOString().split('T')[0];
 
 Empty.args = {
   commons: [],
+  date: date
 };
 
 export const ThreeItemsOrdinaryUser = Template.bind({});
 
 ThreeItemsOrdinaryUser.args = {
   commons: diningCommonsFixtures.fourCommons,
+  date: date
 };
 
 export const ThreeItemsAdminUser = Template.bind({});
 ThreeItemsAdminUser.args = {
   commons: diningCommonsFixtures.fourCommons,
+  date: date
 };

--- a/frontend/src/stories/pages/HomePage.stories.js
+++ b/frontend/src/stories/pages/HomePage.stories.js
@@ -3,6 +3,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { http, HttpResponse } from "msw";
 
 import HomePage from "main/pages/HomePage";
+import { diningCommonsFixtures } from "../../fixtures/diningCommonsFixtures";
 
 export default {
   title: "pages/HomePage",
@@ -21,6 +22,9 @@ LoggedOut.parameters = {
       http.get("/api/systemInfo", () => {
         return HttpResponse.json(systemInfoFixtures.showingNeither);
       }),
+      http.get("/api/dining/all", () => {
+        return HttpResponse.json(diningCommonsFixtures.fourCommons);
+      }),
     ],
   },
 };
@@ -34,6 +38,9 @@ LoggedInRegularUser.parameters = {
       }),
       http.get("/api/systemInfo", () => {
         return HttpResponse.json(systemInfoFixtures.showingNeither);
+      }),
+      http.get("/api/dining/all", () => {
+        return HttpResponse.json(diningCommonsFixtures.fourCommons);
       }),
     ],
   },

--- a/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
+++ b/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
@@ -1,4 +1,4 @@
-import { waitFor, render, screen } from "@testing-library/react";
+import { waitFor, render, screen, within } from "@testing-library/react";
 import { diningCommonsFixtures } from "fixtures/diningCommonsFixtures";
 import DiningCommonsTable from "main/components/DiningCommons/DiningCommonsTable";
 import { QueryClient, QueryClientProvider } from "react-query";
@@ -46,108 +46,16 @@ describe("DiningCommonsTable tests", () => {
     );
 
     // assert - check that the expected content is rendered
-
-    await waitFor(() => {
+    await screen.findByTestId("DiningCommonsTable-cell-row-0-col-code");
+    for (let i = 0; i < diningCommonsFixtures.fourCommons.length; i++) {
       expect(
-        screen.getByTestId(`DiningCommonsTable-cell-row-0-col-code`),
-      ).toHaveTextContent("carrillo");
-    });
-
-    await waitFor(() => {
+          screen.getByTestId(`DiningCommonsTable-cell-row-${i}-col-code`),
+      ).toBeInTheDocument();
       expect(
-        screen.getByTestId(`DiningCommonsTable-cell-row-1-col-code`),
-      ).toHaveTextContent("de-la-guerra");
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId(`DiningCommonsTable-cell-row-2-col-code`),
-      ).toHaveTextContent("ortega");
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId(`DiningCommonsTable-cell-row-3-col-code`),
-      ).toHaveTextContent("portola");
-    });
-
-    // assert - check that the checkmarks and X's are available
-
-    // carrillo
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("DiningCommonsTable-cell-row-0-col-hasSackMeal"),
-      ).toHaveTextContent("❌");
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("DiningCommonsTable-cell-row-0-col-hasTakeoutMeal"),
-      ).toHaveTextContent("❌");
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("DiningCommonsTable-cell-row-0-col-hasDiningCam"),
-      ).toHaveTextContent("✅");
-    });
-
-    // de la guerra
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("DiningCommonsTable-cell-row-1-col-hasSackMeal"),
-      ).toHaveTextContent("❌");
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("DiningCommonsTable-cell-row-1-col-hasTakeoutMeal"),
-      ).toHaveTextContent("❌");
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("DiningCommonsTable-cell-row-1-col-hasDiningCam"),
-      ).toHaveTextContent("✅");
-    });
-
-    // ortega
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("DiningCommonsTable-cell-row-2-col-hasSackMeal"),
-      ).toHaveTextContent("✅");
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("DiningCommonsTable-cell-row-2-col-hasTakeoutMeal"),
-      ).toHaveTextContent("✅");
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("DiningCommonsTable-cell-row-2-col-hasDiningCam"),
-      ).toHaveTextContent("✅");
-    });
-
-    // portola
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("DiningCommonsTable-cell-row-3-col-hasSackMeal"),
-      ).toHaveTextContent("✅");
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("DiningCommonsTable-cell-row-3-col-hasTakeoutMeal"),
-      ).toHaveTextContent("✅");
-    });
-
-    await waitFor(() => {
-      expect(
-        screen.getByTestId("DiningCommonsTable-cell-row-3-col-hasDiningCam"),
-      ).toHaveTextContent("✅");
-    });
+        screen
+          .getByText(diningCommonsFixtures.fourCommons[i].code)
+      ).toHaveProperty("href", `http://localhost/diningcommons/${diningCommonsFixtures.fourCommons[i].code}`)
+    }
   });
 
   test("Checkmark / X for Boolean columns shows up as expected when hasDiningCam is false", async () => {

--- a/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
+++ b/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
@@ -1,4 +1,4 @@
-import { waitFor, render, screen, within } from "@testing-library/react";
+import { waitFor, render, screen } from "@testing-library/react";
 import { diningCommonsFixtures } from "fixtures/diningCommonsFixtures";
 import DiningCommonsTable from "main/components/DiningCommons/DiningCommonsTable";
 import { QueryClient, QueryClientProvider } from "react-query";

--- a/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
+++ b/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
@@ -13,7 +13,7 @@ jest.mock("react-router-dom", () => ({
 
 describe("DiningCommonsTable tests", () => {
   const queryClient = new QueryClient();
-
+  const fourCommons = diningCommonsFixtures.fourCommons;
   const expectedHeaders = [
     "Code",
     "Name",
@@ -47,14 +47,17 @@ describe("DiningCommonsTable tests", () => {
 
     // assert - check that the expected content is rendered
     await screen.findByTestId("DiningCommonsTable-cell-row-0-col-code");
-    for (let i = 0; i < diningCommonsFixtures.fourCommons.length; i++) {
+    for (let i = 0; i < fourCommons.length; i++) {
       expect(
           screen.getByTestId(`DiningCommonsTable-cell-row-${i}-col-code`),
       ).toBeInTheDocument();
       expect(
         screen
-          .getByText(diningCommonsFixtures.fourCommons[i].code)
-      ).toHaveProperty("href", `http://localhost/diningcommons/${diningCommonsFixtures.fourCommons[i].code}`)
+          .getByText(fourCommons[i].code)
+      ).toHaveAttribute("href", `/diningcommons/${fourCommons[i].code}`)
+      expect(screen.getByTestId(`DiningCommonsTable-cell-row-${i}-col-hasSackMeal`)).toHaveTextContent(fourCommons[i].hasSackMeal ? "✅" : "❌");
+      expect(screen.getByTestId(`DiningCommonsTable-cell-row-${i}-col-hasTakeoutMeal`)).toHaveTextContent(fourCommons[i].hasTakeoutMeal ? "✅" : "❌");
+      expect(screen.getByTestId(`DiningCommonsTable-cell-row-${i}-col-hasDiningCam`)).toHaveTextContent(fourCommons[i].hasDiningCam ? "✅" : "❌");
     }
   });
 

--- a/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
+++ b/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
@@ -33,14 +33,15 @@ describe("DiningCommonsTable tests", () => {
     "longitude",
   ];
   const testId = "DiningCommonsTable";
+  const date = new Date("2025-03-11").toISOString().split("T")[0];
 
-  test("Checkmark / X for Boolean columns shows up as expected", async () => {
+  test("Checkmark / X for Boolean columns shows up as expected, url shows up correctly", async () => {
     // act - render the component
 
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <DiningCommonsTable commons={diningCommonsFixtures.fourCommons} />
+          <DiningCommonsTable commons={diningCommonsFixtures.fourCommons} date={date}/>
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -53,7 +54,7 @@ describe("DiningCommonsTable tests", () => {
       ).toBeInTheDocument();
       expect(screen.getByText(fourCommons[i].code)).toHaveAttribute(
         "href",
-        `/diningcommons/${fourCommons[i].code}`,
+        `/diningcommons/2025-03-11/${fourCommons[i].code}`,
       );
       expect(
         screen.getByTestId(`DiningCommonsTable-cell-row-${i}-col-hasSackMeal`),
@@ -77,6 +78,7 @@ describe("DiningCommonsTable tests", () => {
         <MemoryRouter>
           <DiningCommonsTable
             commons={[diningCommonsFixtures.oneCommonsDiningCamFalse]}
+            date={date}
           />
         </MemoryRouter>
       </QueryClientProvider>,
@@ -96,7 +98,7 @@ describe("DiningCommonsTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <DiningCommonsTable commons={[]} />
+          <DiningCommonsTable commons={[]} date={date}/>
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -120,7 +122,7 @@ describe("DiningCommonsTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <DiningCommonsTable commons={diningCommonsFixtures.fourCommons} />
+          <DiningCommonsTable commons={diningCommonsFixtures.fourCommons} date={date}/>
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -156,7 +158,7 @@ describe("DiningCommonsTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <DiningCommonsTable commons={diningCommonsFixtures.fourCommons} />
+          <DiningCommonsTable commons={diningCommonsFixtures.fourCommons} date={date}/>
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -191,7 +193,7 @@ describe("DiningCommonsTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <DiningCommonsTable commons={diningCommonsFixtures.fourCommons} />
+          <DiningCommonsTable commons={diningCommonsFixtures.fourCommons} date={date}/>
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -238,7 +240,7 @@ describe("DiningCommonsTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <DiningCommonsTable commons={diningCommonsFixtures.fourCommons} />
+          <DiningCommonsTable commons={diningCommonsFixtures.fourCommons} date={date}/>
         </MemoryRouter>
       </QueryClientProvider>,
     );

--- a/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
+++ b/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
@@ -41,7 +41,10 @@ describe("DiningCommonsTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <DiningCommonsTable commons={diningCommonsFixtures.fourCommons} date={date}/>
+          <DiningCommonsTable
+            commons={diningCommonsFixtures.fourCommons}
+            date={date}
+          />
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -98,7 +101,7 @@ describe("DiningCommonsTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <DiningCommonsTable commons={[]} date={date}/>
+          <DiningCommonsTable commons={[]} date={date} />
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -122,7 +125,10 @@ describe("DiningCommonsTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <DiningCommonsTable commons={diningCommonsFixtures.fourCommons} date={date}/>
+          <DiningCommonsTable
+            commons={diningCommonsFixtures.fourCommons}
+            date={date}
+          />
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -158,7 +164,10 @@ describe("DiningCommonsTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <DiningCommonsTable commons={diningCommonsFixtures.fourCommons} date={date}/>
+          <DiningCommonsTable
+            commons={diningCommonsFixtures.fourCommons}
+            date={date}
+          />
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -193,7 +202,10 @@ describe("DiningCommonsTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <DiningCommonsTable commons={diningCommonsFixtures.fourCommons} date={date}/>
+          <DiningCommonsTable
+            commons={diningCommonsFixtures.fourCommons}
+            date={date}
+          />
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -240,7 +252,10 @@ describe("DiningCommonsTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <DiningCommonsTable commons={diningCommonsFixtures.fourCommons} date={date}/>
+          <DiningCommonsTable
+            commons={diningCommonsFixtures.fourCommons}
+            date={date}
+          />
         </MemoryRouter>
       </QueryClientProvider>,
     );

--- a/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
+++ b/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
@@ -49,15 +49,23 @@ describe("DiningCommonsTable tests", () => {
     await screen.findByTestId("DiningCommonsTable-cell-row-0-col-code");
     for (let i = 0; i < fourCommons.length; i++) {
       expect(
-          screen.getByTestId(`DiningCommonsTable-cell-row-${i}-col-code`),
+        screen.getByTestId(`DiningCommonsTable-cell-row-${i}-col-code`),
       ).toBeInTheDocument();
+      expect(screen.getByText(fourCommons[i].code)).toHaveAttribute(
+        "href",
+        `/diningcommons/${fourCommons[i].code}`,
+      );
       expect(
-        screen
-          .getByText(fourCommons[i].code)
-      ).toHaveAttribute("href", `/diningcommons/${fourCommons[i].code}`)
-      expect(screen.getByTestId(`DiningCommonsTable-cell-row-${i}-col-hasSackMeal`)).toHaveTextContent(fourCommons[i].hasSackMeal ? "✅" : "❌");
-      expect(screen.getByTestId(`DiningCommonsTable-cell-row-${i}-col-hasTakeoutMeal`)).toHaveTextContent(fourCommons[i].hasTakeoutMeal ? "✅" : "❌");
-      expect(screen.getByTestId(`DiningCommonsTable-cell-row-${i}-col-hasDiningCam`)).toHaveTextContent(fourCommons[i].hasDiningCam ? "✅" : "❌");
+        screen.getByTestId(`DiningCommonsTable-cell-row-${i}-col-hasSackMeal`),
+      ).toHaveTextContent(fourCommons[i].hasSackMeal ? "✅" : "❌");
+      expect(
+        screen.getByTestId(
+          `DiningCommonsTable-cell-row-${i}-col-hasTakeoutMeal`,
+        ),
+      ).toHaveTextContent(fourCommons[i].hasTakeoutMeal ? "✅" : "❌");
+      expect(
+        screen.getByTestId(`DiningCommonsTable-cell-row-${i}-col-hasDiningCam`),
+      ).toHaveTextContent(fourCommons[i].hasDiningCam ? "✅" : "❌");
     }
   });
 

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -27,10 +27,15 @@ describe("HomePage tests", () => {
     axiosMock
       .onGet("/api/dining/all")
       .reply(200, diningCommonsFixtures.fourCommons);
+    let date = new Date("2025-03-11")
+    jest.useFakeTimers({advanceTimers: true});
+    jest.setSystemTime(date);
+
   });
   afterEach(() => {
     axiosMock.reset();
     queryClient.clear();
+    jest.useRealTimers();
   });
   test("Renders table with 4 dining commons", async () => {
     render(
@@ -46,6 +51,9 @@ describe("HomePage tests", () => {
       expect(
         screen.getByTestId(`DiningCommonsTable-cell-row-${i}-col-code`),
       ).toHaveTextContent(diningCommonsFixtures.fourCommons[i].code);
+      expect(
+          screen.getByText(diningCommonsFixtures.fourCommons[i].code)
+      ).toHaveAttribute("href", `/diningcommons/2025-03-11/${diningCommonsFixtures.fourCommons[i].code}`);
     }
   });
 });

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import HomePage from "main/pages/HomePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -7,18 +7,32 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import { diningCommonsFixtures } from "../../fixtures/diningCommonsFixtures";
+import mockConsole from "jest-mock-console";
 
 describe("HomePage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
-  axiosMock
-    .onGet("/api/currentUser")
-    .reply(200, apiCurrentUserFixtures.userOnly);
-  axiosMock
-    .onGet("/api/systemInfo")
-    .reply(200, systemInfoFixtures.showingNeither);
-
-  const queryClient = new QueryClient();
-  test("renders without crashing", async () => {
+  let axiosMock;
+  let queryClient;
+  beforeAll(() => {
+    axiosMock = new AxiosMockAdapter(axios);
+    queryClient = new QueryClient();
+  });
+  beforeEach(() => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock
+      .onGet("/api/dining/all")
+      .reply(200, diningCommonsFixtures.fourCommons);
+  });
+  afterEach(() => {
+    axiosMock.reset();
+    queryClient.clear();
+  });
+  test("Renders table with 4 dining commons", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -26,6 +40,52 @@ describe("HomePage tests", () => {
         </MemoryRouter>
       </QueryClientProvider>,
     );
-    await screen.findByText(/Hello, world!/);
+
+    await screen.findByTestId("DiningCommonsTable-cell-row-0-col-code");
+    for (let i = 0; i < diningCommonsFixtures.fourCommons.length; i++) {
+      expect(
+        screen.getByTestId(`DiningCommonsTable-cell-row-${i}-col-code`),
+      ).toHaveTextContent(diningCommonsFixtures.fourCommons[i].code);
+    }
+  });
+});
+
+describe("HomePage renders properly with no backend", () => {
+  let axiosMock;
+  const queryClient = new QueryClient();
+  beforeAll(() => {
+    axiosMock = new AxiosMockAdapter(axios);
+    queryClient.clear();
+  });
+  beforeEach(() => {
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+    axiosMock.onGet("/api/dining/all").timeout();
+  });
+
+  test("Renders without crashing with no backend", async () => {
+    const restoreConsole = mockConsole();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HomePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/dining/all",
+    );
+    restoreConsole();
+    expect(
+      screen.queryByTestId("DiningCommonsTable-cell-row-0-col-code"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -27,10 +27,9 @@ describe("HomePage tests", () => {
     axiosMock
       .onGet("/api/dining/all")
       .reply(200, diningCommonsFixtures.fourCommons);
-    let date = new Date("2025-03-11")
-    jest.useFakeTimers({advanceTimers: true});
+    let date = new Date("2025-03-11");
+    jest.useFakeTimers({ advanceTimers: true });
     jest.setSystemTime(date);
-
   });
   afterEach(() => {
     axiosMock.reset();
@@ -52,8 +51,11 @@ describe("HomePage tests", () => {
         screen.getByTestId(`DiningCommonsTable-cell-row-${i}-col-code`),
       ).toHaveTextContent(diningCommonsFixtures.fourCommons[i].code);
       expect(
-          screen.getByText(diningCommonsFixtures.fourCommons[i].code)
-      ).toHaveAttribute("href", `/diningcommons/2025-03-11/${diningCommonsFixtures.fourCommons[i].code}`);
+        screen.getByText(diningCommonsFixtures.fourCommons[i].code),
+      ).toHaveAttribute(
+        "href",
+        `/diningcommons/2025-03-11/${diningCommonsFixtures.fourCommons[i].code}`,
+      );
     }
   });
 });

--- a/src/main/java/edu/ucsb/cs156/dining/models/DiningCommons.java
+++ b/src/main/java/edu/ucsb/cs156/dining/models/DiningCommons.java
@@ -1,9 +1,13 @@
 package edu.ucsb.cs156.dining.models;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import java.util.Map;
+
+import static java.lang.Double.parseDouble;
 
 @Builder
 @Data
@@ -17,6 +21,14 @@ public class DiningCommons {
   private Boolean hasTakeOutMeal;
   private Double latitude;
   private Double longitude;
+
+
+  //Found this on Baeldung for unpacking nested json properties: https://www.baeldung.com/jackson-nested-values
+  @JsonProperty("location")
+  private void unpackedNested(Map<String,Object> location){
+    this.latitude = (Double) location.get("latitude");
+    this.longitude = (Double) location.get("longitude");
+  }
 
   public static final String SAMPLE_CARRILLO =
       """

--- a/src/test/java/edu/ucsb/cs156/dining/services/DiningCommonsServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/services/DiningCommonsServiceTests.java
@@ -58,8 +58,10 @@ class DiningCommonsServiceTests {
               \"hasDiningCam\": \"%s\",
               \"hasSackMeal\": \"%s\",
               \"hasTakeOutMeal\": \"%s\",
-              \"longitude\": \"%s\",
-              \"latitude\": \"%s\"
+              \"location\":{
+                \"longitude\": %s,
+                \"latitude\": %s
+              }
             }
             ]
             """,
@@ -69,7 +71,7 @@ class DiningCommonsServiceTests {
             HASSACKMEAL,
             HASTAKEOUTMEAL,
             LONGITUDE,
-            LATITUDE.toString());
+            LATITUDE);
 
     DiningCommons expectedCommons =
         DiningCommons.builder()

--- a/src/test/java/edu/ucsb/cs156/dining/web/HomePageWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/dining/web/HomePageWebIT.java
@@ -48,7 +48,7 @@ public class HomePageWebIT {
         String url = String.format("http://localhost:%d/", port);
         page.navigate(url);
 
-        assertThat(page.getByText("This is a webapp containing a bunch of different Spring Boot/React examples."))
+        assertThat(page.getByText("Dining Commons"))
                 .isVisible();
     }
 


### PR DESCRIPTION
In this PR, I add the list of dining commons to the home page. To do so, I tweak the dining commons table to include links to the relevant dining commons pages. Has 100% code coverage and passes mutation.