### PR TITLE
Refactoring the Database Connections on Review, MenuItem, and User

### DIFF
--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.dining.controllers;
 
+import edu.ucsb.cs156.dining.entities.MenuItem;
 import edu.ucsb.cs156.dining.entities.Review;
 import edu.ucsb.cs156.dining.entities.User;
 import edu.ucsb.cs156.dining.errors.EntityNotFoundException;
@@ -111,14 +112,12 @@ public class ReviewController extends ApiController {
 
         review.setItemsStars(itemsStars);
 
-        // Check if the menu item exists
-        if (!menuItemRepository.existsById(itemId)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "MenuItem with id " + itemId + " not found");
-        }
-
-        review.setItemId(itemId);
+        MenuItem reviewedItem = menuItemRepository.findById(itemId).orElseThrow(
+                () -> new EntityNotFoundException(MenuItem.class, itemId)
+        );
+        review.setItem(reviewedItem);
         CurrentUser user = getCurrentUser();
-        review.setStudentId(user.getUser().getId());
+        review.setReviewer(user.getUser());
         review.setDateEdited(now);
         log.info("reviews={}", review);
         reviewRepository.save(review);
@@ -135,8 +134,7 @@ public class ReviewController extends ApiController {
     @GetMapping("/userReviews")
     public Iterable<Review> get_all_review_by_user_id(){
         CurrentUser user = getCurrentUser();
-        long userId = user.getUser().getId();
-        Iterable<Review> reviews = reviewRepository.findAllByStudentId(userId);
+        Iterable<Review> reviews = reviewRepository.findByReviewer(user.getUser());
         return reviews;
     }
 }

--- a/src/main/java/edu/ucsb/cs156/dining/entities/MenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/dining/entities/MenuItem.java
@@ -1,19 +1,22 @@
 package edu.ucsb.cs156.dining.entities;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+
+import java.util.List;
 
 
-/** 
+/**
  * This is a JPA entity that represents a MenuItem
- * 
- * A MenuItem represents a actual menu item in a dining commons at UCSB
+ *
+ * A MenuItem represents an actual menu item in a dining commons at UCSB
  */
 
 @Data
@@ -21,13 +24,20 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @Entity(name = "menuitem")
+@JsonIdentityInfo(
+        generator = ObjectIdGenerators.PropertyGenerator.class,
+        property = "id")
 public class MenuItem {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;
-  
+
   private String diningCommonsCode;
   private String mealCode;
   private String name;
   private String station;
+
+  @OneToMany(mappedBy = "item")
+  @Fetch(FetchMode.JOIN)
+  private List<Review> reviews;
 }

--- a/src/main/java/edu/ucsb/cs156/dining/entities/MenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/dining/entities/MenuItem.java
@@ -3,10 +3,7 @@ package edu.ucsb.cs156.dining.entities;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
@@ -37,6 +34,7 @@ public class MenuItem {
   private String name;
   private String station;
 
+  @ToString.Exclude
   @OneToMany(mappedBy = "item")
   @Fetch(FetchMode.JOIN)
   private List<Review> reviews;

--- a/src/main/java/edu/ucsb/cs156/dining/entities/Review.java
+++ b/src/main/java/edu/ucsb/cs156/dining/entities/Review.java
@@ -1,5 +1,8 @@
 package edu.ucsb.cs156.dining.entities;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
@@ -14,6 +17,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 
@@ -23,17 +28,13 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Builder
 @Entity(name = "reviews")
+@JsonIdentityInfo(
+        generator = ObjectIdGenerators.PropertyGenerator.class,
+        property = "id")
 public class Review {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-
-    @Column(nullable = false)
-    private long studentId;
-
-    @Column(nullable = false)
-    private Long itemId;
-
 
     @Column(columnDefinition = "VARCHAR(255) DEFAULT NULL")
     private String reviewerComments;
@@ -54,10 +55,18 @@ public class Review {
 
     @Column(columnDefinition = "VARCHAR(255) DEFAULT NULL")
     private String moderatorComments;
-        
+
     @Column(nullable = false)
     private LocalDateTime dateCreated;
 
     @Column(nullable = false)
     private LocalDateTime dateEdited;
+
+    @ManyToOne
+    @JoinColumn(name = "item_id", nullable = false)
+    private MenuItem item;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User reviewer;
 }

--- a/src/main/java/edu/ucsb/cs156/dining/entities/Review.java
+++ b/src/main/java/edu/ucsb/cs156/dining/entities/Review.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs156.dining.entities;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import edu.ucsb.cs156.dining.statuses.ModerationStatus;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
@@ -48,7 +49,7 @@ public class Review {
     private LocalDateTime dateItemServed;
 
     @Column(nullable = false, columnDefinition = "VARCHAR(255) DEFAULT 'Awaiting Moderation'")
-    private String status = "Awaiting Moderation";
+    private ModerationStatus status = ModerationStatus.AWAITING_REVIEW;
 
     @Column(columnDefinition = "VARCHAR(255) DEFAULT NULL")
     private String userIdModerator;

--- a/src/main/java/edu/ucsb/cs156/dining/entities/Review.java
+++ b/src/main/java/edu/ucsb/cs156/dining/entities/Review.java
@@ -3,7 +3,6 @@ package edu.ucsb.cs156.dining.entities;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-import edu.ucsb.cs156.dining.statuses.ModerationStatus;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
@@ -49,7 +48,7 @@ public class Review {
     private LocalDateTime dateItemServed;
 
     @Column(nullable = false, columnDefinition = "VARCHAR(255) DEFAULT 'Awaiting Moderation'")
-    private ModerationStatus status = ModerationStatus.AWAITING_REVIEW;
+    private String status = "Awaiting Moderation";
 
     @Column(columnDefinition = "VARCHAR(255) DEFAULT NULL")
     private String userIdModerator;

--- a/src/main/java/edu/ucsb/cs156/dining/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/dining/entities/User.java
@@ -3,12 +3,9 @@ package edu.ucsb.cs156.dining.entities;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import edu.ucsb.cs156.dining.statuses.ModerationStatus;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
@@ -43,12 +40,12 @@ public class User {
  private boolean admin;
  private String alias;
  private String proposedAlias;
- private String status;
+ private ModerationStatus status;
  private LocalDate dateApproved;
 
+ @ToString.Exclude
  @OneToMany(mappedBy="reviewer")
  @Fetch(FetchMode.JOIN)
- @JsonIgnore
  private List<Review> reviews;
  
  public String getAlias() {

--- a/src/main/java/edu/ucsb/cs156/dining/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/dining/entities/User.java
@@ -3,7 +3,6 @@ package edu.ucsb.cs156.dining.entities;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-import edu.ucsb.cs156.dining.statuses.ModerationStatus;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Fetch;
@@ -40,7 +39,7 @@ public class User {
  private boolean admin;
  private String alias;
  private String proposedAlias;
- private ModerationStatus status;
+ private String status;
  private LocalDate dateApproved;
 
  @ToString.Exclude

--- a/src/main/java/edu/ucsb/cs156/dining/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/dining/entities/User.java
@@ -1,16 +1,19 @@
 package edu.ucsb.cs156.dining.entities;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 
 import java.time.LocalDate;
+import java.util.List;
 
 /**
 * This is a JPA entity that represents a user.
@@ -21,6 +24,9 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @Entity(name = "users")
+@JsonIdentityInfo(
+        generator = ObjectIdGenerators.PropertyGenerator.class,
+        property = "id")
 public class User {
  @Id
  @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,6 +45,11 @@ public class User {
  private String proposedAlias;
  private String status;
  private LocalDate dateApproved;
+
+ @OneToMany(mappedBy="reviewer")
+ @Fetch(FetchMode.JOIN)
+ @JsonIgnore
+ private List<Review> reviews;
  
  public String getAlias() {
         if (this.alias == null) {

--- a/src/main/java/edu/ucsb/cs156/dining/repositories/ReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/dining/repositories/ReviewRepository.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.dining.repositories;
 
 import edu.ucsb.cs156.dining.entities.Review;
 
+import edu.ucsb.cs156.dining.entities.User;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
@@ -15,11 +16,11 @@ public interface ReviewRepository extends CrudRepository<Review, Long> {
 
     /**
      * 
-     * @param studentId
+     * @param user
      * @return all reviews that have come from a single reviewer, ex say this user has made a few reviews over the past year
      * well then this method will return only the reviews that this user has sent 
      */
 
-    Iterable<Review> findAllByStudentId(long studentId); 
+    Iterable<Review> findByReviewer(User user);
 
 }

--- a/src/main/resources/db/migration/changes/Reviews.json
+++ b/src/main/resources/db/migration/changes/Reviews.json
@@ -29,22 +29,32 @@
                       "autoIncrement": true,
                       "constraints": {
                         "primaryKey": true,
-                        "primaryKeyName": "CONSTRAINT_9"
+                        "primaryKeyName": "REVIEWS_PK"
                       }
-                    }
-                  },
-                  {
-                    "column": {
-                      "name": "STUDENT_ID",
-                      "type": "BIGINT",
-                      "constraints": {"nullable": false}
                     }
                   },
                   {
                     "column": {
                       "name": "ITEM_ID",
                       "type": "BIGINT",
-                      "constraints": {"nullable": false}
+                      "constraints": {
+                        "foreignKeyName": "FK_ITEM_ID",
+                        "referencedTableName": "REVIEWS",
+                        "referencedColumnName": "ID",
+                        "nullable": false
+                      }
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "USER_ID",
+                      "type": "BIGINT",
+                      "constraints": {
+                        "foreignKeyName": "FK_USER_ID",
+                        "referencedTableName": "USERS",
+                        "referencedColumnName": "ID",
+                        "nullable": false
+                      }
                     }
                   },
                   {

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
@@ -1,6 +1,9 @@
 package edu.ucsb.cs156.dining.controllers;
 
+import edu.ucsb.cs156.dining.errors.EntityNotFoundException;
 import edu.ucsb.cs156.dining.repositories.UserRepository;
+import edu.ucsb.cs156.dining.services.CurrentUserService;
+import edu.ucsb.cs156.dining.testconfig.MockCurrentUserServiceImpl;
 import edu.ucsb.cs156.dining.testconfig.TestConfig;
 import edu.ucsb.cs156.dining.ControllerTestCase;
 import edu.ucsb.cs156.dining.entities.MenuItem;
@@ -18,18 +21,24 @@ import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.cglib.core.Local;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.server.ResponseStatusException;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.http.Request;
 
@@ -44,382 +53,401 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @WebMvcTest(controllers = ReviewController.class)
 @Import(TestConfig.class)
 public class ReviewControllerTests extends ControllerTestCase {
 
-        @MockBean
-        ReviewRepository reviewRepository;
+    @MockBean
+    ReviewRepository reviewRepository;
 
-        @Autowired
-        private ObjectMapper mapper;
+    @Autowired
+    private ObjectMapper mapper;
 
-        @MockBean
-        UserRepository userRepository;
+    @MockBean
+    UserRepository userRepository;
 
-        @MockBean
-        private MenuItemRepository menuItemRepository;
+    @MockBean
+    private MenuItemRepository menuItemRepository;
+    @Autowired
+    private CurrentUserService currentUserService;
 
-        @BeforeEach
-        void setup() {
+    @MockBean
+    DateTimeProvider dateTimeProvider;
+
+    @BeforeEach
+    void setup() {
         // Assume an item exists with ID 1
         when(menuItemRepository.existsById(1L)).thenReturn(true);
+        when(menuItemRepository.findById(1L)).thenReturn(Optional.of(MenuItem.builder().id(1L).build()));
         when(menuItemRepository.existsById(5L)).thenReturn(false);
         when(menuItemRepository.existsById(313L)).thenReturn(true);
-
+        when(dateTimeProvider.getNow()).thenReturn(Optional.of(LocalDateTime.of(2025,3,11,0,0,0)));
         // Assume no item exists with ID 999
         when(menuItemRepository.existsById(999L)).thenReturn(false);
-        }
+    }
 
-        // Authorization tests for /api/request
+    // Authorization tests for /api/request
 
-        @Test
-        public void logged_out_users_cannot_get_all() throws Exception {
-                mockMvc.perform(get("/api/reviews/all"))
-                                .andExpect(status().is(403)); // logged out users can't get all
-        }
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+        mockMvc.perform(get("/api/reviews/all"))
+                .andExpect(status().is(403)); // logged out users can't get all
+    }
 
-        @WithMockUser(roles = { "ADMIN" })
-        @Test
-        public void logged_in_admin_can_get_all() throws Exception {
-                mockMvc.perform(get("/api/reviews/all"))
-                                .andExpect(status().is(200));
-        }
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void logged_in_admin_can_get_all() throws Exception {
+        mockMvc.perform(get("/api/reviews/all"))
+                .andExpect(status().is(200));
+    }
 
-        @WithMockUser(roles = { "USER" })
-        @Test
-        public void logged_in_user_cant_get_all() throws Exception {
-                mockMvc.perform(get("/api/reviews/all"))
-                                .andExpect(status().is(403));
-        }
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void logged_in_user_cant_get_all() throws Exception {
+        mockMvc.perform(get("/api/reviews/all"))
+                .andExpect(status().is(403));
+    }
 
-        @Test
-        public void logged_out_users_cannot_post() throws Exception {
-                mockMvc.perform(post("/api/reviews/post"))
-                                .andExpect(status().is(403));
-        }
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/reviews/post"))
+                .andExpect(status().is(403));
+    }
 
-        @WithMockUser(roles = { "USER" })
-        @Test
-        public void a_user_can_post_a_new_review() throws Exception {
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void a_user_can_post_a_new_review() throws Exception {
 
-                // Arrange
-                LocalDateTime now = LocalDateTime.now();
+        // Arrange
+        LocalDateTime now = LocalDateTime.now();
 
-                Review review = Review.builder()
-                                .dateCreated(now)
-                                .dateEdited(now)
-                                .itemsStars(1l)
-                                .reviewerComments("Worst flavor ever.")
-                                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
-                                .studentId(1L)
-                                .status("Awaiting Moderation")
-                                .itemId(1L)
-                                .id(0L)
-                                .build();
-                when(reviewRepository.save(eq(review))).thenReturn(review);
+        User user = currentUserService.getUser();
+        MenuItem menuItem = MenuItem.builder().id(1L).build();
 
-                // Act
-                MvcResult response = mockMvc.perform(
-                                post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
-                                                .with(csrf()))
-                                .andExpect(status().isOk())
-                                .andReturn();
+        Review review = Review.builder()
+                .dateCreated(now)
+                .dateEdited(now)
+                .itemsStars(1l)
+                .reviewerComments("Worst flavor ever.")
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
+                .reviewer(user)
+                .status("Awaiting Moderation")
+                .item(menuItem)
+                .id(0L)
+                .build();
+        when(reviewRepository.save(eq(review))).thenReturn(review);
 
-                String jsonReview = mapper.writeValueAsString(review);
+        // Act
+        MvcResult response = mockMvc.perform(
+                        post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
+                                .with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn();
 
-                // Assert
-                verify(reviewRepository).save(any(Review.class));
-                JsonNode responseJson = mapper.readTree(response.getResponse().getContentAsString());
-                JsonNode expectedJson = mapper.readTree(jsonReview);
+        String jsonReview = mapper.writeValueAsString(review);
 
-                assertEquals(expectedJson.get("studentId").asInt(), responseJson.get("studentId").asInt());
-                assertEquals(expectedJson.get("itemsStars").asInt(), responseJson.get("itemsStars").asInt());
-                assertEquals(expectedJson.get("status").asText(), responseJson.get("status").asText());
-                assertEquals(expectedJson.get("itemId").asInt(), responseJson.get("itemId").asInt());
-                assertEquals(expectedJson.get("reviewerComments").asText(),
-                                responseJson.get("reviewerComments").asText());
+        // Assert
+        verify(reviewRepository).save(any(Review.class));
+        JsonNode responseJson = mapper.readTree(response.getResponse().getContentAsString());
+        JsonNode expectedJson = mapper.readTree(jsonReview);
 
-                // Manually compare important date fields with a threshold for acceptable
-                // variation
-                checkDates(expectedJson, responseJson, "dateItemServed");
-                checkDates(expectedJson, responseJson, "dateCreated");
-                checkDates(expectedJson, responseJson, "dateEdited");
-        }
+        assertEquals(expectedJson.get("itemsStars").asInt(), responseJson.get("itemsStars").asInt());
+        assertEquals(expectedJson.get("status").asText(), responseJson.get("status").asText());
+        assertEquals(expectedJson.get("reviewerComments").asText(),
+                responseJson.get("reviewerComments").asText());
+        assertEquals(expectedJson.get("reviewer").asText(),
+                responseJson.get("reviewer").asText());
+        assertEquals(expectedJson.get("item").asText(), responseJson.get("item").asText());
 
-        @WithMockUser(roles = { "USER" })
-        @Test
-        public void test_rating_below_1_throws_exception() throws Exception {
-            mockMvc.perform(
-                    post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=0&dateItemServed=2021-12-12T08:08:08")
-                    .with(csrf()))
-                    .andDo(print()) // This helps you see the full response for debugging
-                    .andExpect(status().isBadRequest());
-        }
+        // Manually compare important date fields with a threshold for acceptable
+        // variation
+        checkDates(expectedJson, responseJson, "dateItemServed");
+        checkDates(expectedJson, responseJson, "dateCreated");
+        checkDates(expectedJson, responseJson, "dateEdited");
+    }
 
-        @WithMockUser(roles = { "USER" })
-        @Test
-        public void test_rating_above_5_throws_exception() throws Exception {
-            mockMvc.perform(
-                    post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=6&dateItemServed=2021-12-12T08:08:08")
-                    .with(csrf()))
-                    .andDo(print()) // This helps you see the full response for debugging
-                    .andExpect(status().isBadRequest());
-        }
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void test_rating_below_1_throws_exception() throws Exception {
+        mockMvc.perform(
+                        post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=0&dateItemServed=2021-12-12T08:08:08")
+                                .with(csrf()))
+                .andDo(print()) // This helps you see the full response for debugging
+                .andExpect(status().isBadRequest());
+    }
 
-            // Test valid input at boundaries
-    @WithMockUser(roles = { "USER" })
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void test_rating_above_5_throws_exception() throws Exception {
+        mockMvc.perform(
+                        post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=6&dateItemServed=2021-12-12T08:08:08")
+                                .with(csrf()))
+                .andDo(print()) // This helps you see the full response for debugging
+                .andExpect(status().isBadRequest());
+    }
+
+    // Test valid input at boundaries
+    @WithMockUser(roles = {"USER"})
     @Test
     public void postReview_ShouldAcceptRatingAtBoundaries() throws Exception {
         // Lower boundary test
         mockMvc.perform(
-                post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
-                .with(csrf()))
-            .andExpect(status().isOk());
+                        post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
+                                .with(csrf()))
+                .andExpect(status().isOk());
         // Lower boundary test
         mockMvc.perform(
-                post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=5&dateItemServed=2021-12-12T08:08:08")
-                .with(csrf()))
-            .andExpect(status().isOk());
+                        post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=5&dateItemServed=2021-12-12T08:08:08")
+                                .with(csrf()))
+                .andExpect(status().isOk());
     }
 
 
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void test_emptyString_on_creating_new_review() throws Exception {
 
-        @WithMockUser(roles = { "USER" })
-        @Test
-        public void test_emptyString_on_creating_new_review() throws Exception {
+        // Arrange
+        LocalDateTime now = LocalDateTime.now();
 
-                // Arrange
-                LocalDateTime now = LocalDateTime.now();
+        User user = currentUserService.getUser();
+        MenuItem menuItem = MenuItem.builder().id(1L).build();
 
-                Review review = Review.builder()
-                                .dateCreated(now)
-                                .dateEdited(now)
-                                .itemsStars(1l)
-                                .reviewerComments("   ")
-                                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
-                                .studentId(1L)
-                                .status("Awaiting Moderation")
-                                .itemId(1L)
-                                .id(0L)
-                                .build();
-                when(reviewRepository.save(eq(review))).thenReturn(review);
+        Review review = Review.builder()
+                .dateCreated(now)
+                .dateEdited(now)
+                .itemsStars(1l)
+                .reviewerComments("   ")
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
+                .reviewer(user)
+                .status("Awaiting Moderation")
+                .item(menuItem)
+                .id(0L)
+                .build();
+        when(reviewRepository.save(eq(review))).thenReturn(review);
 
-                // Act
-                MvcResult response = mockMvc.perform(
-                                post("/api/reviews/post?itemId=1&reviewerComments=   &itemsStars=1&dateItemServed=2021-12-12T08:08:08")
+        // Act
+        MvcResult response = mockMvc.perform(
+                        post("/api/reviews/post?itemId=1&reviewerComments=   &itemsStars=1&dateItemServed=2021-12-12T08:08:08")
                                 .with(csrf()))
-                                .andExpect(status().isOk())
-                                .andReturn();
+                .andExpect(status().isOk())
+                .andReturn();
 
-                String jsonReview = mapper.writeValueAsString(review);
+        String jsonReview = mapper.writeValueAsString(review);
 
-                // Assert
-                verify(reviewRepository).save(any(Review.class));
-                JsonNode responseJson = mapper.readTree(response.getResponse().getContentAsString());
-                JsonNode expectedJson = mapper.readTree(jsonReview);
+        // Assert
+        verify(reviewRepository).save(any(Review.class));
+        JsonNode responseJson = mapper.readTree(response.getResponse().getContentAsString());
+        JsonNode expectedJson = mapper.readTree(jsonReview);
 
-                assertTrue(responseJson.get("reviewerComments").isNull());
-        }
+        assertTrue(responseJson.get("reviewerComments").isNull());
+    }
 
-        @WithMockUser(roles = { "USER" })
-        @Test
-        public void test_no_string_on_creating_new_review() throws Exception {
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void test_no_string_on_creating_new_review() throws Exception {
 
-                // Arrange
-                LocalDateTime now = LocalDateTime.now();
+        // Arrange
+        LocalDateTime now = LocalDateTime.now();
 
-                Review review = Review.builder()
-                                .dateCreated(now)
-                                .dateEdited(now)
-                                .itemsStars(1l)
-                                .reviewerComments(null)
-                                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
-                                .studentId(1L)
-                                .status("Awaiting Moderation")
-                                .itemId(1L)
-                                .id(0L)
-                                .build();
-                when(reviewRepository.save(eq(review))).thenReturn(review);
+        User user = currentUserService.getUser();
+        MenuItem menuItem = MenuItem.builder().id(1L).build();
 
-                // Act
-                MvcResult response = mockMvc.perform(
-                                post("/api/reviews/post?itemId=1&reviewerComments=&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
-                                                .with(csrf()))
-                                .andExpect(status().isOk())
-                                .andReturn();
+        Review review = Review.builder()
+                .dateCreated(now)
+                .dateEdited(now)
+                .itemsStars(1l)
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
+                .reviewer(user)
+                .status("Awaiting Moderation")
+                .item(menuItem)
+                .id(0L)
+                .build();
+        when(reviewRepository.save(eq(review))).thenReturn(review);
 
-                // Assert
-                verify(reviewRepository).save(any(Review.class));
-                JsonNode responseJson = mapper.readTree(response.getResponse().getContentAsString());
-                assertTrue(responseJson.get("reviewerComments").isNull());
-
-        }
-
-        @WithMockUser(roles = { "ADMIN" })
-        @Test
-        public void a_logged_in_admin_can_get_all() throws Exception {
-                // Arrange
-
-                LocalDateTime now = LocalDateTime.now();
-
-                Review review1 = Review.builder()
-                                .dateCreated(now)
-                                .dateEdited(now)
-                                .itemsStars(3l)
-                                .reviewerComments("Im tired of this same chicken")
-                                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
-                                .studentId(1L)
-                                .status("Awaiting Moderation")
-                                .itemId(313L)
-                                .id(0L)
-                                .build();
-
-                Review review2 = Review.builder()
-                                .dateCreated(now.plusDays(4))
-                                .dateEdited(now.plusDays(5))
-                                .itemsStars(5l)
-                                .reviewerComments("MMMMM I LOVE CHICKEN")
-                                .dateItemServed(LocalDateTime.of(2022, 7, 1, 8, 8, 8))
-                                .studentId(2L)
-                                .status("Awaiting Moderation")
-                                .itemId(1L)
-                                .id(0L)
-                                .build();
-
-                Review review3 = Review.builder()
-                                .dateCreated(now)
-                                .dateEdited(now)
-                                .itemsStars(6l)
-                                .reviewerComments("Im tired of this same chicken")
-                                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
-                                .studentId(1L)
-                                .status("Awaiting Moderation")
-                                .itemId(313L)
-                                .id(0L)
-                                .build();
-
-                ArrayList<Review> reviews = new ArrayList<>();
-                reviews.addAll(Arrays.asList(review1, review2, review3));
-
-                when(reviewRepository.findAll()).thenReturn(reviews);
-                // Act
-                MvcResult response = mockMvc.perform(get("/api/reviews/all"))
-                                .andExpect(status().is(200)).andReturn();
-
-                // assert
-                verify(reviewRepository, times(1)).findAll();
-                String expectedJson = mapper.writeValueAsString(reviews);
-                String responseString = response.getResponse().getContentAsString();
-                assertEquals(expectedJson, responseString);
-        }
-
-
-        @WithMockUser(roles = { "USER" })
-        @Test
-        public void a_logged_in_user_can_get_own_reviews_list() throws Exception {
-                // Arrange
-
-                Review review1 = Review.builder()
-                                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3 ))
-                                .studentId(1L)
-                                .status("Awaiting Moderation")
-                                .itemId(1L)
-                                .id(1L)
-                                .build();
-
-                Review review2 = Review.builder()
-                                .dateCreated(LocalDateTime.of(2024, 4, 28, 1, 47))
-                                .dateEdited(LocalDateTime.of(2024, 7, 2, 6, 47))
-                                .dateItemServed(LocalDateTime.of(2022, 2, 6, 8, 8))
-                                .studentId(2L)
-                                .status("Awaiting Moderation")
-                                .itemId(1L)
-                                .id(2L)
-                                .build();
-                
-                Review review3 = Review.builder()
-                                .dateCreated(LocalDateTime.of(2024, 2, 17, 2, 47))
-                                .dateEdited(LocalDateTime.of(2024, 12, 15, 04, 26))
-                                .dateItemServed(LocalDateTime.of(2023, 1, 7, 3, 8))
-                                .studentId(2L)
-                                .status("Awaiting Moderation")
-                                .itemId(1L)
-                                .id(3L)
-                                .build();
-
-                ArrayList<Review> reviews = new ArrayList<>();
-                ArrayList<Review> valid_reviews = new ArrayList<>();
-                valid_reviews.addAll(Arrays.asList(review1));
-                reviews.addAll(Arrays.asList(review1, review2,review3));
-                when(reviewRepository.findAllByStudentId(1)).thenReturn(valid_reviews);
-
-                // Act
-                MvcResult response = mockMvc.perform(
-                                get("/api/reviews/userReviews")
+        // Act
+        MvcResult response = mockMvc.perform(
+                        post("/api/reviews/post?itemId=1&reviewerComments=&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
                                 .with(csrf()))
-                                .andExpect(status().isOk())
-                                .andReturn();
+                .andExpect(status().isOk())
+                .andReturn();
 
-                // assert
-                verify(reviewRepository, times(1)).findAllByStudentId(1);
-                String expectedJson = mapper.writeValueAsString(valid_reviews);
-                String responseString = response.getResponse().getContentAsString();
-                assertEquals(expectedJson, responseString);
+        // Assert
+        verify(reviewRepository).save(any(Review.class));
+        JsonNode responseJson = mapper.readTree(response.getResponse().getContentAsString());
+        assertTrue(responseJson.get("reviewerComments").isNull());
 
-        }
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void a_logged_in_admin_can_get_all() throws Exception {
+        // Arrange
+
+        LocalDateTime now = LocalDateTime.now();
+
+        User user1 = currentUserService.getUser();
+        User user2 = User.builder().id(2L).build();
+        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+        MenuItem menuItem2 = MenuItem.builder().id(313L).build();
+
+        Review review1 = Review.builder()
+                .dateCreated(now)
+                .dateEdited(now)
+                .itemsStars(3l)
+                .reviewerComments("Im tired of this same chicken")
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
+                .reviewer(user1)
+                .status("Awaiting Moderation")
+                .item(menuItem1)
+                .id(0L)
+                .build();
+
+        Review review2 = Review.builder()
+                .dateCreated(now.plusDays(4))
+                .dateEdited(now.plusDays(5))
+                .itemsStars(5l)
+                .reviewerComments("MMMMM I LOVE CHICKEN")
+                .dateItemServed(LocalDateTime.of(2022, 7, 1, 8, 8, 8))
+                .reviewer(user2)
+                .status("Awaiting Moderation")
+                .item(menuItem2)
+                .id(0L)
+                .build();
+
+        Review review3 = Review.builder()
+                .dateCreated(now)
+                .dateEdited(now)
+                .itemsStars(6l)
+                .reviewerComments("Im tired of this same chicken")
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
+                .reviewer(user1)
+                .status("Awaiting Moderation")
+                .item(menuItem2)
+                .id(0L)
+                .build();
+
+        ArrayList<Review> reviews = new ArrayList<>();
+        reviews.addAll(Arrays.asList(review1, review2, review3));
+
+        when(reviewRepository.findAll()).thenReturn(reviews);
+        // Act
+        MvcResult response = mockMvc.perform(get("/api/reviews/all"))
+                .andExpect(status().is(200)).andReturn();
+
+        // assert
+        verify(reviewRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(reviews);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
 
 
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void a_logged_in_user_can_get_own_reviews_list() throws Exception {
+        // Arrange
+        User user1 = currentUserService.getUser();
+        User user2 = User.builder().id(2L).build();
+        CurrentUser currentUser = CurrentUser.builder().user(user1).build();
+
+        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+        MenuItem menuItem2 = MenuItem.builder().id(313L).build();
+
+        Review review1 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user1)
+                .status("Awaiting Moderation")
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+        Review review2 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 4, 28, 1, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 6, 47))
+                .dateItemServed(LocalDateTime.of(2022, 2, 6, 8, 8))
+                .reviewer(user2)
+                .status("Awaiting Moderation")
+                .item(menuItem1)
+                .id(2L)
+                .build();
+
+        Review review3 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 2, 17, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 12, 15, 04, 26))
+                .dateItemServed(LocalDateTime.of(2023, 1, 7, 3, 8))
+                .reviewer(user2)
+                .status("Awaiting Moderation")
+                .item(menuItem2)
+                .id(3L)
+                .build();
+
+        ArrayList<Review> reviews = new ArrayList<>();
+        ArrayList<Review> valid_reviews = new ArrayList<>();
+        valid_reviews.addAll(Arrays.asList(review1));
+        reviews.addAll(Arrays.asList(review1, review2, review3));
+        when(reviewRepository.findByReviewer(eq(user1))).thenReturn(valid_reviews);
+
+        // Act
+        MvcResult response = mockMvc.perform(
+                        get("/api/reviews/userReviews")
+                                .with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // assert
+        verify(reviewRepository, times(1)).findByReviewer(eq(user1));
+        String expectedJson = mapper.writeValueAsString(valid_reviews);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+
+    }
 
 
-        @WithMockUser(roles = {"USER"})
-        @Test
-        public void testItemIdIsInvalid_NotFound() throws Exception {
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void testItemIdIsInvalid_NotFound() throws Exception {
 
-            // Act: Perform the request and expect the review creation to fail due to non-existing itemId
-            mockMvc.perform(post("/api/reviews/post")
-                    .param("itemId", "5")  // This itemId does not exist
-                    .param("reviewerComments", "")
-                    .param("itemsStars", "1")
-                    .param("dateItemServed", "2021-12-12T08:08:08")
-                    .with(csrf()))
+        // Act: Perform the request and expect the review creation to fail due to non-existing itemId
+        mockMvc.perform(post("/api/reviews/post")
+                        .param("itemId", "5")  // This itemId does not exist
+                        .param("reviewerComments", "")
+                        .param("itemsStars", "1")
+                        .param("dateItemServed", "2021-12-12T08:08:08")
+                        .with(csrf()))
                 .andExpect(status().isNotFound())
-                .andExpect(result -> assertTrue(result.getResolvedException() instanceof ResponseStatusException))
-                .andExpect(result -> assertEquals("404 NOT_FOUND \"MenuItem with id 5 not found\"", result.getResolvedException().getMessage()));
-        
-            // Assert: Ensure no reviews are saved due to invalid itemId
-            verify(reviewRepository, times(0)).save(any(Review.class));
-        }
+                .andExpect(result -> assertTrue(result.getResolvedException() instanceof EntityNotFoundException))
+                .andExpect(result -> assertEquals("MenuItem with id 5 not found", result.getResolvedException().getMessage()));
 
-        /**
-         * checkDates function is needed for checking and asserting the time of the
-         * expected response and the instantiated review
-         * Their is a few millisecond delay from the mocked request and the creation of
-         * the objects instance,
-         * therefore, the time is off. Thus when checking against one another, we allow
-         * some tolerance.
-         * 
-         * @param expectedJson
-         * @param responseJson
-         * @param fieldName
-         */
-        private void checkDates(JsonNode expectedJson, JsonNode responseJson, String fieldName) {
-                if (expectedJson.hasNonNull(fieldName) && responseJson.hasNonNull(fieldName)) {
-                        LocalDateTime expectedDate = LocalDateTime.parse(expectedJson.get(fieldName).asText());
-                        LocalDateTime actualDate = LocalDateTime.parse(responseJson.get(fieldName).asText());
-                        assertTrue(Math.abs(Duration.between(expectedDate, actualDate).toMillis()) < 1000,
-                                        fieldName + " times are too far apart");
-                } else {
-                        throw new IllegalStateException(fieldName + " should not be null");
-                }
-        }
+        // Assert: Ensure no reviews are saved due to invalid itemId
+        verify(reviewRepository, times(0)).save(any(Review.class));
+    }
 
+    /**
+     * checkDates function is needed for checking and asserting the time of the
+     * expected response and the instantiated review
+     * There is a few millisecond delay from the mocked request and the creation of
+     * the objects instance,
+     * therefore, the time is off. Thus when checking against one another, we allow
+     * some tolerance.
+     *
+     * @param expectedJson JSON you're expecting to see
+     * @param responseJson JSON you actually received
+     * @param fieldName    field in the JSON
+     */
+    private void checkDates(JsonNode expectedJson, JsonNode responseJson, String fieldName) {
+        if (expectedJson.hasNonNull(fieldName) && responseJson.hasNonNull(fieldName)) {
+            LocalDateTime expectedDate = LocalDateTime.parse(expectedJson.get(fieldName).asText());
+            LocalDateTime actualDate = LocalDateTime.parse(responseJson.get(fieldName).asText());
+            assertTrue(Math.abs(Duration.between(expectedDate, actualDate).toMillis()) < 1000,
+                    fieldName + " times are too far apart");
+        } else {
+            throw new IllegalStateException(fieldName + " should not be null");
+        }
+    }
 
 
 }

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsControllerTests.java
@@ -93,7 +93,7 @@ public class UCSBDiningMenuItemsControllerTests extends ControllerTestCase {
         menuItemRepository.save(item);
 
       when(menuItemRepository.findByDiningCommonsCodeAndMealCodeAndNameAndStation(diningCommonCode, mealCode, name, station))
-            .thenReturn(Optional.of(new MenuItem(1L, diningCommonCode, mealCode, name, station)));
+            .thenReturn(Optional.of(new MenuItem(1L, diningCommonCode, mealCode, name, station, null)));
 
       assertEquals(item.getDiningCommonsCode(), "portola");
       assertEquals(item.getMealCode(), "dinner");

--- a/src/test/java/edu/ucsb/cs156/dining/testconfig/TestConfig.java
+++ b/src/test/java/edu/ucsb/cs156/dining/testconfig/TestConfig.java
@@ -22,5 +22,4 @@ public class TestConfig {
     public GrantedAuthoritiesService grantedAuthoritiesService() {
         return new GrantedAuthoritiesService();
     }
-
 }


### PR DESCRIPTION
In this PR, I refactor the entity files for `MenuItem`, `Review`, and `User` to include ManyToOne relationships for their respective items. A review includes a reference to the user who created it and the menu item reviewed. Both the `User` and the `MenuItem` classes include a list of reviews that is mapped by their respective columns in the Review table.

All 3 of these entities include a Jackson Object Mapper `@JsonIdentityInfo` annotation to prevent the JSON outputs from looping indefinitely. Referenced properties are also excluded from the toString, as to prevent toString overflows.

In addition, I updated the `ReviewController` tests to match the new backend. This has 100% test coverage and killls the mutations.

This is currently available at https://dining-division7.dokku-00.cs.ucsb.edu/