### PR TITLE
Adding Review DELETE and PUT endpoints

### DIFF
--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
@@ -141,7 +141,7 @@ public class ReviewController extends ApiController {
 
     @Operation(summary = "Edit a review")
     @PreAuthorize("hasRole('ROLE_USER')")
-    @PutMapping
+    @PutMapping("/reviewer")
     public Review editReview(@Parameter Long id, @RequestBody @Valid EditedReview incoming) {
 
         Review oldReview = reviewRepository.findById(id).orElseThrow(
@@ -176,7 +176,7 @@ public class ReviewController extends ApiController {
 
     @Operation(summary = "Delete a review")
     @PreAuthorize("hasRole('ROLE_USER')")
-    @DeleteMapping
+    @DeleteMapping("/reviewer")
     public Object deleteReview(@Parameter Long id) {
         Review review = reviewRepository.findById(id).orElseThrow(
                 () -> new EntityNotFoundException(Review.class, id)

--- a/src/main/java/edu/ucsb/cs156/dining/models/EditedReview.java
+++ b/src/main/java/edu/ucsb/cs156/dining/models/EditedReview.java
@@ -1,0 +1,18 @@
+package edu.ucsb.cs156.dining.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class EditedReview {
+    private Long itemStars;
+    private String reviewerComments;
+    private LocalDateTime dateItemServed;
+}

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
@@ -467,7 +467,7 @@ public class ReviewControllerTests extends ControllerTestCase {
 
         when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
 
-        MvcResult response = mockMvc.perform(put("/api/reviews")
+        MvcResult response = mockMvc.perform(put("/api/reviews/reviewer")
                 .param("id", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("utf-8")
@@ -510,13 +510,13 @@ public class ReviewControllerTests extends ControllerTestCase {
 
         when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
 
-        mockMvc.perform(put("/api/reviews")
+        mockMvc.perform(put("/api/reviews/reviewer")
                 .param("id", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("utf-8")
                 .content(requestBodyTooLow)
                 .with(csrf())).andExpect(status().isBadRequest()).andReturn();
-        mockMvc.perform(put("/api/reviews")
+        mockMvc.perform(put("/api/reviews/reviewer")
                 .param("id", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("utf-8")
@@ -552,7 +552,7 @@ public class ReviewControllerTests extends ControllerTestCase {
 
         when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
 
-        mockMvc.perform(put("/api/reviews")
+        mockMvc.perform(put("/api/reviews/reviewer")
                 .param("id", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("utf-8")
@@ -588,7 +588,7 @@ public class ReviewControllerTests extends ControllerTestCase {
 
         when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
 
-        mockMvc.perform(put("/api/reviews")
+        mockMvc.perform(put("/api/reviews/reviewer")
                 .param("id", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("utf-8")
@@ -637,7 +637,7 @@ public class ReviewControllerTests extends ControllerTestCase {
 
         String requestBody = mapper.writeValueAsString(reviewEdit);
 
-        MvcResult response = mockMvc.perform(put("/api/reviews")
+        MvcResult response = mockMvc.perform(put("/api/reviews/reviewer")
                 .param("id", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("utf-8")
@@ -693,7 +693,7 @@ public class ReviewControllerTests extends ControllerTestCase {
 
         String requestBody = mapper.writeValueAsString(reviewEdit);
 
-        MvcResult response = mockMvc.perform(put("/api/reviews")
+        MvcResult response = mockMvc.perform(put("/api/reviews/reviewer")
                 .param("id", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("utf-8")
@@ -750,7 +750,7 @@ public class ReviewControllerTests extends ControllerTestCase {
 
         String requestBody = mapper.writeValueAsString(reviewEdit);
 
-        MvcResult response = mockMvc.perform(put("/api/reviews")
+        MvcResult response = mockMvc.perform(put("/api/reviews/reviewer")
                 .param("id", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("utf-8")
@@ -777,7 +777,7 @@ public class ReviewControllerTests extends ControllerTestCase {
 
         String requestBody = mapper.writeValueAsString(reviewEdit);
 
-        MvcResult response = mockMvc.perform(put("/api/reviews")
+        MvcResult response = mockMvc.perform(put("/api/reviews/reviewer")
                 .param("id", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("utf-8")
@@ -811,7 +811,7 @@ public class ReviewControllerTests extends ControllerTestCase {
 
         when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
 
-        MvcResult response = mockMvc.perform(delete("/api/reviews")
+        MvcResult response = mockMvc.perform(delete("/api/reviews/reviewer")
                 .param("id", "1")
                 .with(csrf())).andExpect(status().isForbidden()).andReturn();
 
@@ -838,7 +838,7 @@ public class ReviewControllerTests extends ControllerTestCase {
 
         when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
 
-        MvcResult response = mockMvc.perform(delete("/api/reviews")
+        MvcResult response = mockMvc.perform(delete("/api/reviews/reviewer")
                 .param("id", "1")
                 .with(csrf())).andExpect(status().isOk()).andReturn();
 
@@ -867,7 +867,7 @@ public class ReviewControllerTests extends ControllerTestCase {
 
         when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
 
-        MvcResult response = mockMvc.perform(delete("/api/reviews")
+        MvcResult response = mockMvc.perform(delete("/api/reviews/reviewer")
                 .param("id", "1")
                 .with(csrf())).andExpect(status().isOk()).andReturn();
 
@@ -881,7 +881,7 @@ public class ReviewControllerTests extends ControllerTestCase {
     public void nonexistent_cannot_delete() throws Exception{
         when(reviewRepository.findById(eq(1L))).thenReturn(Optional.empty());
 
-        MvcResult response = mockMvc.perform(delete("/api/reviews")
+        MvcResult response = mockMvc.perform(delete("/api/reviews/reviewer")
                 .param("id", "1")
                 .with(csrf())).andExpect(status().isNotFound()).andReturn();
 

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.dining.controllers;
 
 import edu.ucsb.cs156.dining.errors.EntityNotFoundException;
+import edu.ucsb.cs156.dining.models.EditedReview;
 import edu.ucsb.cs156.dining.repositories.UserRepository;
 import edu.ucsb.cs156.dining.services.CurrentUserService;
 import edu.ucsb.cs156.dining.statuses.ModerationStatus;
@@ -71,6 +72,7 @@ public class ReviewControllerTests extends ControllerTestCase {
 
     @MockBean
     private MenuItemRepository menuItemRepository;
+
     @Autowired
     private CurrentUserService currentUserService;
 
@@ -362,7 +364,6 @@ public class ReviewControllerTests extends ControllerTestCase {
         // Arrange
         User user1 = currentUserService.getUser();
         User user2 = User.builder().id(2L).build();
-        CurrentUser currentUser = CurrentUser.builder().user(user1).build();
 
         MenuItem menuItem1 = MenuItem.builder().id(1L).build();
         MenuItem menuItem2 = MenuItem.builder().id(313L).build();
@@ -437,6 +438,457 @@ public class ReviewControllerTests extends ControllerTestCase {
         // Assert: Ensure no reviews are saved due to invalid itemId
         verify(reviewRepository, times(0)).save(any(Review.class));
     }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void wrong_user_cannot_edit() throws Exception{
+        User user2 = User.builder().id(2L).build();
+
+        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+        Review review1 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user2)
+                .status(ModerationStatus.AWAITING_REVIEW)
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+        EditedReview reviewEdit = EditedReview.builder()
+                .reviewerComments("test")
+                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+                .itemStars(2L)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(reviewEdit);
+
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+
+        MvcResult response = mockMvc.perform(put("/api/reviews")
+                .param("id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf())).andExpect(status().isForbidden()).andReturn();
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void cannot_set_stars_over_boundaries() throws Exception{
+        User user1 = currentUserService.getUser();
+
+        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+        Review review1 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user1)
+                .status(ModerationStatus.AWAITING_REVIEW)
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+        EditedReview reviewTooLow = EditedReview.builder()
+                .reviewerComments("test")
+                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+                .itemStars(0L)
+                .build();
+
+        EditedReview reviewTooHigh = EditedReview.builder()
+                .reviewerComments("test")
+                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+                .itemStars(6L)
+                .build();
+
+        String requestBodyTooLow = mapper.writeValueAsString(reviewTooLow);
+        String requestBodyTooHigh = mapper.writeValueAsString(reviewTooHigh);
+
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+
+        mockMvc.perform(put("/api/reviews")
+                .param("id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBodyTooLow)
+                .with(csrf())).andExpect(status().isBadRequest()).andReturn();
+        mockMvc.perform(put("/api/reviews")
+                .param("id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBodyTooHigh)
+                .with(csrf())).andExpect(status().isBadRequest()).andReturn();
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void can_set_stars_at_low_boundary() throws Exception{
+        User user1 = currentUserService.getUser();
+
+        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+        Review review1 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user1)
+                .status(ModerationStatus.AWAITING_REVIEW)
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+        EditedReview review = EditedReview.builder()
+                .reviewerComments("test")
+                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+                .itemStars(1L)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(review);
+
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+
+        mockMvc.perform(put("/api/reviews")
+                .param("id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf())).andExpect(status().isOk()).andReturn();
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void can_set_stars_at_high_boundary() throws Exception{
+        User user1 = currentUserService.getUser();
+
+        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+        Review review1 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user1)
+                .status(ModerationStatus.AWAITING_REVIEW)
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+        EditedReview review = EditedReview.builder()
+                .reviewerComments("test")
+                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+                .itemStars(5L)
+                .build();
+
+        String requestBody = mapper.writeValueAsString(review);
+
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+
+        mockMvc.perform(put("/api/reviews")
+                .param("id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf())).andExpect(status().isOk()).andReturn();
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void trim_works_correctly() throws Exception{
+        User user1 = currentUserService.getUser();
+
+        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+        Review review1 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user1)
+                .status(ModerationStatus.AWAITING_REVIEW)
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+        EditedReview reviewEdit = EditedReview.builder()
+                .reviewerComments("   ")
+                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+                .itemStars(2L)
+                .build();
+
+        Review reviewResponse = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+                .reviewer(user1)
+                .reviewerComments(null)
+                .itemsStars(2L)
+                .status(ModerationStatus.AWAITING_REVIEW)
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+        when(reviewRepository.save(eq(reviewResponse))).thenReturn(reviewResponse);
+
+
+        String requestBody = mapper.writeValueAsString(reviewEdit);
+
+        MvcResult response = mockMvc.perform(put("/api/reviews")
+                .param("id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf())).andExpect(status().isOk()).andReturn();
+
+        String reviewJson = mapper.writeValueAsString(reviewResponse);
+        String responseJson = response.getResponse().getContentAsString();
+        verify(reviewRepository, times(1)).findById(eq(1L));
+        verify(reviewRepository, times(1)).save(eq(reviewResponse));
+        assertEquals(responseJson, reviewJson);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void null_works_correctly() throws Exception{
+        User user1 = currentUserService.getUser();
+
+        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+        Review review1 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user1)
+                .reviewerComments("there is a comment here.")
+                .status(ModerationStatus.AWAITING_REVIEW)
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+        EditedReview reviewEdit = EditedReview.builder()
+                .reviewerComments(null)
+                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+                .itemStars(2L)
+                .build();
+
+        Review reviewResponse = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+                .reviewer(user1)
+                .reviewerComments(null)
+                .itemsStars(2L)
+                .status(ModerationStatus.AWAITING_REVIEW)
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+        when(reviewRepository.save(eq(reviewResponse))).thenReturn(reviewResponse);
+
+
+        String requestBody = mapper.writeValueAsString(reviewEdit);
+
+        MvcResult response = mockMvc.perform(put("/api/reviews")
+                .param("id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf())).andExpect(status().isOk()).andReturn();
+
+        String reviewJson = mapper.writeValueAsString(reviewResponse);
+        String responseJson = response.getResponse().getContentAsString();
+        verify(reviewRepository, times(1)).findById(eq(1L));
+        verify(reviewRepository, times(1)).save(eq(reviewResponse));
+        assertEquals(responseJson, reviewJson);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void edit_works_correctly() throws Exception{
+        User user1 = currentUserService.getUser();
+
+        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+        Review review1 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user1)
+                .status(ModerationStatus.REJECTED)
+                .moderatorComments("unacceptable")
+                .item(menuItem1)
+                .itemsStars(3L)
+                .id(1L)
+                .build();
+
+        EditedReview reviewEdit = EditedReview.builder()
+                .reviewerComments("test")
+                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+                .itemStars(2L)
+                .build();
+
+        Review reviewResponse = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+                .reviewer(user1)
+                .reviewerComments("test")
+                .itemsStars(2L)
+                .status(ModerationStatus.AWAITING_REVIEW)
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+        when(reviewRepository.save(eq(reviewResponse))).thenReturn(reviewResponse);
+
+
+        String requestBody = mapper.writeValueAsString(reviewEdit);
+
+        MvcResult response = mockMvc.perform(put("/api/reviews")
+                .param("id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf())).andExpect(status().isOk()).andReturn();
+
+        String reviewJson = mapper.writeValueAsString(reviewResponse);
+        String responseJson = response.getResponse().getContentAsString();
+        verify(reviewRepository, times(1)).findById(eq(1L));
+        verify(reviewRepository, times(1)).save(eq(reviewResponse));
+        assertEquals(responseJson, reviewJson);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void not_found_throws_exception() throws Exception{
+        EditedReview reviewEdit = EditedReview.builder()
+                .reviewerComments("test")
+                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+                .itemStars(2L)
+                .build();
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+        String requestBody = mapper.writeValueAsString(reviewEdit);
+
+        MvcResult response = mockMvc.perform(put("/api/reviews")
+                .param("id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf())).andExpect(status().isNotFound()).andReturn();
+
+        verify(reviewRepository, times(1)).findById(eq(1L));
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("Review with id 1 not found", json.get("message"));
+
+    }
+
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void wrong_user_cannot_delete() throws Exception{
+        User user2 = User.builder().id(2L).build();
+
+        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+        Review review1 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user2)
+                .status(ModerationStatus.AWAITING_REVIEW)
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+
+        MvcResult response = mockMvc.perform(delete("/api/reviews")
+                .param("id", "1")
+                .with(csrf())).andExpect(status().isForbidden()).andReturn();
+
+        verify(reviewRepository, times(0)).delete(eq(review1));
+    }
+
+    @WithMockUser(roles = {"ADMIN","USER"})
+    @Test
+    public void admin_can_delete() throws Exception{
+        User user2 = User.builder().id(2L).build();
+
+        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+        Review review1 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user2)
+                .status(ModerationStatus.AWAITING_REVIEW)
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+
+        MvcResult response = mockMvc.perform(delete("/api/reviews")
+                .param("id", "1")
+                .with(csrf())).andExpect(status().isOk()).andReturn();
+
+        verify(reviewRepository, times(1)).delete(eq(review1));
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("Review with id 1 deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void user_can_delete() throws Exception{
+        User user1 = currentUserService.getUser();
+
+        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+        Review review1 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user1)
+                .status(ModerationStatus.AWAITING_REVIEW)
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+
+        MvcResult response = mockMvc.perform(delete("/api/reviews")
+                .param("id", "1")
+                .with(csrf())).andExpect(status().isOk()).andReturn();
+
+        verify(reviewRepository, times(1)).delete(eq(review1));
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("Review with id 1 deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void nonexistent_cannot_delete() throws Exception{
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc.perform(delete("/api/reviews")
+                .param("id", "1")
+                .with(csrf())).andExpect(status().isNotFound()).andReturn();
+
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("Review with id 1 not found", json.get("message"));
+    }
+
 
 
 }

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/UsersControllerTests.java
@@ -92,7 +92,7 @@ public class UsersControllerTests extends ControllerTestCase {
             .emailVerified(true)
             .locale("")
             .hostedDomain("example.org")
-            .admin(false)
+            .admin(true)
             .alias("Anonymous User") 
             .proposedAlias("Chipotle")
             .status(ModerationStatus.AWAITING_REVIEW)

--- a/src/test/java/edu/ucsb/cs156/dining/testconfig/MockCurrentUserServiceImpl.java
+++ b/src/test/java/edu/ucsb/cs156/dining/testconfig/MockCurrentUserServiceImpl.java
@@ -4,6 +4,8 @@ import edu.ucsb.cs156.dining.entities.User;
 import edu.ucsb.cs156.dining.services.CurrentUserServiceImpl;
 
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
@@ -40,7 +42,7 @@ public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
       emailVerified = true;
       locale="";
       hostedDomain="example.org";
-      admin= (user.getUsername().equals("admin"));
+      admin= securityContext.getAuthentication().getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"));
     }
 
     User u = User.builder()


### PR DESCRIPTION
In this PR, I add the `DELETE` and `PUT` endpoints to the `ReviewsController`, as well as the associated tests. As a result, I had to tweak `MockUserServiceImpl` so that when the mock role `ROLE_ADMIN` is added, the accounts are properly marked as admins. As a result, I had to line the UserController tests up with it. Has 100% line and mutation coverage.

Available at https://dining-division7.dokku-00.cs.ucsb.edu/

PUT Endpoint Usage:
- Reviews have 3 editable fields, defined in the model `EditedReview`:
  - comments
  - stars
  - date served
- You must also provide the id of the review you'd like to edit, and must be the person who posted the review.
- It will reset the moderation status and the moderator comments to false.

DELETE Endpoint Usage:
- Provide the id of the review you'd like to delete
- You can only delete a review if you are (a) an admin or (b) the user who created the review
- Otherwise, it will return 403 Forbidden.
