### PR TITLE
Adding Review Moderation Endpoints

### DIFF
--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
@@ -190,4 +190,27 @@ public class ReviewController extends ApiController {
         reviewRepository.delete(review);
         return genericMessage("Review with id %s deleted".formatted(id));
     }
+
+    @Operation(summary = "Moderate a review")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("/moderate")
+    public Review moderateReview(@Parameter Long id, @Parameter ModerationStatus status, @Parameter String moderatorComments) {
+        Review review = reviewRepository.findById(id).orElseThrow(
+                () -> new EntityNotFoundException(Review.class, id)
+        );
+
+        review.setModeratorComments(moderatorComments);
+        review.setStatus(status);
+
+        review = reviewRepository.save(review);
+        return review;
+    }
+
+    @Operation(summary = "See reviews that need moderation")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/needsmoderation")
+    public Iterable<Review> needsmoderation() {
+        Iterable<Review> reviewsList = reviewRepository.findByStatus(ModerationStatus.AWAITING_REVIEW);
+        return reviewsList;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/dining/repositories/ReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/dining/repositories/ReviewRepository.java
@@ -3,6 +3,7 @@ package edu.ucsb.cs156.dining.repositories;
 import edu.ucsb.cs156.dining.entities.Review;
 
 import edu.ucsb.cs156.dining.entities.User;
+import edu.ucsb.cs156.dining.statuses.ModerationStatus;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
@@ -22,5 +23,7 @@ public interface ReviewRepository extends CrudRepository<Review, Long> {
      */
 
     Iterable<Review> findByReviewer(User user);
+
+    Iterable<Review> findByStatus(ModerationStatus moderationStatus);
 
 }

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
@@ -889,6 +889,108 @@ public class ReviewControllerTests extends ControllerTestCase {
         assertEquals("Review with id 1 not found", json.get("message"));
     }
 
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void admin_can_moderate_a_review() throws Exception{
+        User user1 = User.builder().id(2L).build();
+
+        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+        Review review1 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user1)
+                .status(ModerationStatus.AWAITING_REVIEW)
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+        Review approved = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user1)
+                .status(ModerationStatus.APPROVED)
+                .moderatorComments("acceptable")
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+        when(reviewRepository.save(eq(approved))).thenReturn(approved);
+
+        MvcResult response = mockMvc.perform(put("/api/reviews/moderate")
+            .param("id", "1")
+            .param("status", "APPROVED")
+            .param("moderatorComments", "acceptable")
+            .with(csrf()))
+            .andExpect(status().isOk()).andReturn();
+
+        String jsonExpected = mapper.writeValueAsString(approved);
+        String jsonResponse = response.getResponse().getContentAsString();
+        verify(reviewRepository, times(1)).findById(eq(1L));
+        verify(reviewRepository, times(1)).save(eq(approved));
+        assertEquals(jsonExpected, jsonResponse);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void nonexistent_cannot_approve() throws Exception{
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc.perform(put("/api/reviews/moderate")
+                .param("id", "1")
+                .param("status", "APPROVED")
+                .param("moderatorComments", "acceptable")
+                .with(csrf())).andExpect(status().isNotFound()).andReturn();
+
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("Review with id 1 not found", json.get("message"));
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void get_needs_moderation_returns_moderation_needed() throws Exception{
+        User user1 = User.builder().id(2L).build();
+
+        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+        Review review1 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user1)
+                .status(ModerationStatus.AWAITING_REVIEW)
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+        Review review2 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user1)
+                .status(ModerationStatus.AWAITING_REVIEW)
+                .item(menuItem1)
+                .id(2L)
+                .build();
+
+
+        ArrayList<Review> returnableReviews = new ArrayList<>(Arrays.asList(review1, review2));
+
+        when(reviewRepository.findByStatus(eq(ModerationStatus.AWAITING_REVIEW))).thenReturn(returnableReviews);
+
+        MvcResult response = mockMvc.perform(get("/api/reviews/needsmoderation")
+                .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        String expectedJson = mapper.writeValueAsString(returnableReviews);
+        String responseJson = response.getResponse().getContentAsString();
+        verify(reviewRepository, times(1)).findByStatus(eq(ModerationStatus.AWAITING_REVIEW));
+        assertEquals(expectedJson,responseJson);
+    }
+
 
 
 }


### PR DESCRIPTION
In this PR, I add the endpoints `/moderate` and `/needsmoderation` endpoints to the ReviewsController, under `/reviews`. Has 100% mutation and test coverage.

Available at https://dining-division7.dokku-00.cs.ucsb.edu/

`/moderate`:
- requires the id of the review to be moderated, the moderation status to set it to, and the comments
- moderation status must be `APPROVED`, `REJECTED`, or `AWAITING_REVIEW`. Otherwise, Spring will reject it.
- At the moment, can only be accessed by an admin

`/needsmoderation`:
- only accessible by admins
- returns the list of reviews with the status `AWAITING_REVIEW`