### PR TITLE
jw - auto approve reviews without comments

### DIFF
--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
@@ -103,7 +103,7 @@ public class ReviewController extends ApiController {
         review.setDateItemServed(dateItemServed);
 
         // Ensures content of truly empty and sets to null if so
-        if ((!reviewerComments.trim().isEmpty())) {
+        if (reviewerComments != null && !reviewerComments.trim().isEmpty()) {
             review.setReviewerComments(reviewerComments);
         }
 
@@ -117,6 +117,11 @@ public class ReviewController extends ApiController {
         MenuItem reviewedItem = menuItemRepository.findById(itemId).orElseThrow(
                 () -> new EntityNotFoundException(MenuItem.class, itemId)
         );
+
+        if (review.getReviewerComments() == null) {
+            review.setStatus(ModerationStatus.APPROVED);
+        }
+
         review.setItem(reviewedItem);
         CurrentUser user = getCurrentUser();
         review.setReviewer(user.getUser());
@@ -160,13 +165,14 @@ public class ReviewController extends ApiController {
 
         if (incoming.getReviewerComments() != null &&!incoming.getReviewerComments().trim().isEmpty()) {
             oldReview.setReviewerComments(incoming.getReviewerComments());
+            oldReview.setStatus(ModerationStatus.AWAITING_REVIEW);
         }else{
             oldReview.setReviewerComments(null);
+            oldReview.setStatus(ModerationStatus.APPROVED);
         }
 
         oldReview.setDateItemServed(incoming.getDateItemServed());
 
-        oldReview.setStatus(ModerationStatus.AWAITING_REVIEW);
         oldReview.setModeratorComments(null);
 
         Review review = reviewRepository.save(oldReview);

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
@@ -160,7 +160,7 @@ public class ReviewControllerTests extends ControllerTestCase {
         // Assert
         verify(reviewRepository).save(any(Review.class));
         String responseJson = response.getResponse().getContentAsString();
-
+        
         assertEquals(responseJson, jsonReview);
     }
 
@@ -216,7 +216,7 @@ public class ReviewControllerTests extends ControllerTestCase {
                 .reviewerComments(null)
                 .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
                 .reviewer(user)
-                .status(ModerationStatus.AWAITING_REVIEW)
+                .status(ModerationStatus.APPROVED)
                 .item(menuItem)
                 .build();
 
@@ -227,7 +227,7 @@ public class ReviewControllerTests extends ControllerTestCase {
                 .reviewerComments(null)
                 .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
                 .reviewer(user)
-                .status(ModerationStatus.AWAITING_REVIEW)
+                .status(ModerationStatus.APPROVED)
                 .item(menuItem)
                 .id(0L)
                 .build();
@@ -235,7 +235,7 @@ public class ReviewControllerTests extends ControllerTestCase {
 
         // Act
         MvcResult response = mockMvc.perform(
-                        post("/api/reviews/post?itemId=1&reviewerComments=   &itemsStars=1&dateItemServed=2021-12-12T08:08:08")
+                        post("/api/reviews/post?itemId=1&reviewerComments=&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
                                 .with(csrf()))
                 .andExpect(status().isOk())
                 .andReturn();
@@ -263,7 +263,7 @@ public class ReviewControllerTests extends ControllerTestCase {
                 .itemsStars(1l)
                 .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
                 .reviewer(user)
-                .status(ModerationStatus.AWAITING_REVIEW)
+                .status(ModerationStatus.APPROVED)
                 .item(menuItem)
                 .build();
 
@@ -273,7 +273,7 @@ public class ReviewControllerTests extends ControllerTestCase {
                 .itemsStars(1l)
                 .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
                 .reviewer(user)
-                .status(ModerationStatus.AWAITING_REVIEW)
+                .status(ModerationStatus.APPROVED)
                 .item(menuItem)
                 .id(0L)
                 .build();
@@ -281,7 +281,7 @@ public class ReviewControllerTests extends ControllerTestCase {
 
         // Act
         MvcResult response = mockMvc.perform(
-                        post("/api/reviews/post?itemId=1&reviewerComments=&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
+                        post("/api/reviews/post?itemId=1&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
                                 .with(csrf()))
                 .andExpect(status().isOk())
                 .andReturn();
@@ -626,7 +626,7 @@ public class ReviewControllerTests extends ControllerTestCase {
                 .reviewer(user1)
                 .reviewerComments(null)
                 .itemsStars(2L)
-                .status(ModerationStatus.AWAITING_REVIEW)
+                .status(ModerationStatus.APPROVED)
                 .item(menuItem1)
                 .id(1L)
                 .build();
@@ -682,7 +682,7 @@ public class ReviewControllerTests extends ControllerTestCase {
                 .reviewer(user1)
                 .reviewerComments(null)
                 .itemsStars(2L)
-                .status(ModerationStatus.AWAITING_REVIEW)
+                .status(ModerationStatus.APPROVED)
                 .item(menuItem1)
                 .id(1L)
                 .build();


### PR DESCRIPTION
In this PR, we add a cherry-picked commit from team s25-04 for this functionality.

(Original PR:  https://github.com/ucsb-cs156-s25/proj-dining-s25-04/pull/42/files)

Original PR Description follows: 


> To make it easier for both users and moderators, there should be no need to approve a review if it does not have a comment. Therefore, if I create a new review with no comment, or if I edit a previous review to have no comment, it should not require a moderator to approve. Both of these can be tested by navigating to [dokku](https://dining-proj-jw.dokku-04.cs.ucsb.edu/), using swagger, and either creating a review with no comment or editing a prior review to have no comments.

