### PR TITLE
FEATURE: backend code formatting

### DIFF
--- a/.github/workflows/15-backend-format.yml
+++ b/.github/workflows/15-backend-format.yml
@@ -1,0 +1,42 @@
+name: "15-backend-format: Format Java Files"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths: [ src/**, .github/workflows/15-backend-format.yml ]
+  push:
+    branches: [ main ]
+    paths: [ src/** , .github/workflows/15-backend-format.yml]
+
+env:
+  # See: https://github.com/actions/setup-java#supported-distributions
+  JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }}
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Java (version from .java-version file)
+        uses: actions/setup-java@v4
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version-file: ./.java-version
+          cache: 'maven'
+          cache-dependency-path: 'pom.xml'
+
+      - name: Check formatting with Maven
+        run: mvn git-code-format:validate-code-format
+
+      - name: "IF STEP ABOVE FAILS ^^^ you need: mvn git-code-format:format-code"
+        if: failure() # Only run if the previous step failed
+        run: |
+          echo  '# Note :warning:'                               >> $GITHUB_STEP_SUMMARY
+          echo  ''                                               >> $GITHUB_STEP_SUMMARY
+          echo  'Some of your code is improperly formatted. '    >> $GITHUB_STEP_SUMMARY
+          echo  ''                                               >> $GITHUB_STEP_SUMMARY
+          echo  ' To fix it, try running this:               '    >> $GITHUB_STEP_SUMMARY
+          echo  ''                                                >> $GITHUB_STEP_SUMMARY
+          echo  '   `mvn git-code-format:format-code`        '    >> $GITHUB_STEP_SUMMARY 
+          echo  '                                            '    >> $GITHUB_STEP_SUMMARY

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,5 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -362,6 +362,37 @@
           <commitIdGenerationMode>full</commitIdGenerationMode>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>com.cosium.code</groupId>
+        <artifactId>git-code-format-maven-plugin</artifactId>
+        <version>5.3</version>
+        <executions>
+          <!-- On commit, format the modified files -->
+          <execution>
+            <id>install-formatter-hook</id>
+            <goals>
+              <goal>install-hooks</goal>
+            </goals>
+          </execution>
+          <!-- On Maven verify phase, fail if any file
+            (including unmodified) is badly formatted -->
+          <execution>
+            <id>validate-code-format</id>
+            <goals>
+              <goal>validate-code-format</goal>
+            </goals>
+          </execution>
+        </executions>
+        <dependencies>
+          <!-- Enable https://github.com/google/google-java-format -->
+          <dependency>
+            <groupId>com.cosium.code</groupId>
+            <artifactId>google-java-format</artifactId>
+            <version>5.3</version>
+          </dependency>
+        </dependencies>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/edu/ucsb/cs156/dining/ExampleApplication.java
+++ b/src/main/java/edu/ucsb/cs156/dining/ExampleApplication.java
@@ -1,33 +1,29 @@
 package edu.ucsb.cs156.dining;
 
+import edu.ucsb.cs156.dining.services.wiremock.WiremockService;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
-
-import edu.ucsb.cs156.dining.services.wiremock.WiremockService;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-import java.time.ZonedDateTime;
-import java.util.Optional;
-
-/**
- * The ExampleApplication class is the main entry point for the application.
- */
+/** The ExampleApplication class is the main entry point for the application. */
 @SpringBootApplication
 @Slf4j
 @EnableJpaAuditing(dateTimeProviderRef = "utcDateTimeProvider")
 public class ExampleApplication {
 
-  @Autowired
-  WiremockService wiremockService;
+  @Autowired WiremockService wiremockService;
 
   /**
-   * When using the wiremock profile, this method will call the code needed to set up the wiremock services
+   * When using the wiremock profile, this method will call the code needed to set up the wiremock
+   * services
    */
   @Profile("wiremock")
   @Bean
@@ -39,9 +35,7 @@ public class ExampleApplication {
     };
   }
 
-  /**
-   * Hook that can be used to set up any services needed for development
-   */
+  /** Hook that can be used to set up any services needed for development */
   @Profile("development")
   @Bean
   public ApplicationRunner developmentApplicationRunner() {
@@ -59,9 +53,9 @@ public class ExampleApplication {
     };
   }
 
-
-   /**
+  /**
    * The main method is the entry point for the application.
+   *
    * @param args command line arguments, typically unused for Spring Boot applications
    */
   public static void main(String[] args) {

--- a/src/main/java/edu/ucsb/cs156/dining/aop/LoggingAspect.java
+++ b/src/main/java/edu/ucsb/cs156/dining/aop/LoggingAspect.java
@@ -1,6 +1,9 @@
 package edu.ucsb.cs156.dining.aop;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
@@ -9,27 +12,22 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-
 /**
- * This class is an Aspect that logs all invocations of controller methods that are annotated
- * with {@code @RequestMapping}, {@code @GetMapping}, {@code @PostMapping}, {@code @PutMapping}, {@code @DeleteMapping},
- * or {@code @PatchMapping}.
- * 
- * For more information on Aspect Oriented Programming (AOP)
- * and AspectJ, including what a {@code JoinPoint} is, 
- * refer to <a href="https://www.baeldung.com/aspectj">https://www.baeldung.com/aspectj</a> 
+ * This class is an Aspect that logs all invocations of controller methods that are annotated with
+ * {@code @RequestMapping}, {@code @GetMapping}, {@code @PostMapping}, {@code @PutMapping},
+ * {@code @DeleteMapping}, or {@code @PatchMapping}.
+ *
+ * <p>For more information on Aspect Oriented Programming (AOP) and AspectJ, including what a {@code
+ * JoinPoint} is, refer to <a
+ * href="https://www.baeldung.com/aspectj">https://www.baeldung.com/aspectj</a>
  */
-
-
 @Slf4j
 @Aspect
 @Component
 public class LoggingAspect {
   // language=PointcutExpression
-  private static final String pointcut = """
+  private static final String pointcut =
+      """
       @annotation(org.springframework.web.bind.annotation.RequestMapping) ||
       @annotation(org.springframework.web.bind.annotation.GetMapping) ||
       @annotation(org.springframework.web.bind.annotation.PostMapping) ||
@@ -38,31 +36,39 @@ public class LoggingAspect {
       @annotation(org.springframework.web.bind.annotation.PatchMapping)
       """;
 
-  private ArrayList<String> stoplist = new ArrayList<String>(Arrays.asList(
-      "edu.ucsb.cs156.dining.controllers.FrontendProxyController"));
+  private ArrayList<String> stoplist =
+      new ArrayList<String>(
+          Arrays.asList("edu.ucsb.cs156.dining.controllers.FrontendProxyController"));
 
   /**
    * This method is called before any controller method that is annotated with
-   * {@code @RequestMapping}, {@code @GetMapping}, {@code @PostMapping}, {@code @PutMapping}, {@code @DeleteMapping},
-   * or {@code @PatchMapping}.
+   * {@code @RequestMapping}, {@code @GetMapping}, {@code @PostMapping}, {@code @PutMapping},
+   * {@code @DeleteMapping}, or {@code @PatchMapping}.
+   *
    * @param joinPoint the join point (injected by Spring framework)
    */
   @Before(pointcut)
   public void logControllers(JoinPoint joinPoint) {
-    getCurrentHttpRequest().ifPresent(
-        request -> {
-          String declaringTypeName = joinPoint.getSignature().getDeclaringTypeName();
-          if (!stoplist.contains(declaringTypeName)) {
-            log.info("===== %s %s handled by %s in %s".formatted(request.getMethod(), request.getRequestURI(),
-                joinPoint.getSignature().getName(), declaringTypeName));
-          }
-        });
+    getCurrentHttpRequest()
+        .ifPresent(
+            request -> {
+              String declaringTypeName = joinPoint.getSignature().getDeclaringTypeName();
+              if (!stoplist.contains(declaringTypeName)) {
+                log.info(
+                    "===== %s %s handled by %s in %s"
+                        .formatted(
+                            request.getMethod(),
+                            request.getRequestURI(),
+                            joinPoint.getSignature().getName(),
+                            declaringTypeName));
+              }
+            });
   }
 
   /**
    * The function `getCurrentHttpRequest` returns an `Optional` containing the current
    * `HttpServletRequest` if available.
-   * 
+   *
    * @return An Optional object containing the current HttpServletRequest, if available.
    */
   private static Optional<HttpServletRequest> getCurrentHttpRequest() {

--- a/src/main/java/edu/ucsb/cs156/dining/config/OpenAPIConfig.java
+++ b/src/main/java/edu/ucsb/cs156/dining/config/OpenAPIConfig.java
@@ -5,17 +5,17 @@ import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.servers.Server;
 
 /**
- * The `OpenAPIConfig` class is annotated with OpenAPI definitions including information about the API
- * and server configuration.
+ * The `OpenAPIConfig` class is annotated with OpenAPI definitions including information about the
+ * API and server configuration.
  */
 @OpenAPIDefinition(
-  info = @Info(
-  title = "Swagger: UCSB CMPSC 156 proj-dining",
-  description = """
+    info =
+        @Info(
+            title = "Swagger: UCSB CMPSC 156 proj-dining",
+            description =
+                """
     <p><a href='/'>Home Page</a></p>
     <p><a href='/h2-console'>H2 Console (only on localhost)</a></p>
-    """     
-    ),
-  servers = @Server(url = "/")
-)
+    """),
+    servers = @Server(url = "/"))
 class OpenAPIConfig {}

--- a/src/main/java/edu/ucsb/cs156/dining/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/dining/config/SecurityConfig.java
@@ -1,44 +1,13 @@
 package edu.ucsb.cs156.dining.config;
 
+import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
+
 import edu.ucsb.cs156.dining.entities.User;
 import edu.ucsb.cs156.dining.repositories.UserRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
-import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
-import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
-import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
-import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
-import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
-import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
-import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
-import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
-import org.springframework.security.web.csrf.CsrfToken;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.util.StringUtils;
-import org.springframework.web.filter.OncePerRequestFilter;
-
-import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
-
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -47,11 +16,34 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
+import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
- * The `SecurityConfig` class in Java configures web security with OAuth2 login,
- * CSRF protection, and
- * role-based authorization based on user email addresses.
+ * The `SecurityConfig` class in Java configures web security with OAuth2 login, CSRF protection,
+ * and role-based authorization based on user email addresses.
  */
 @Configuration
 @EnableWebSecurity
@@ -62,38 +54,41 @@ public class SecurityConfig {
   @Value("${app.admin.emails}")
   private final List<String> adminEmails = new ArrayList<>();
 
-  @Autowired
-  UserRepository userRepository;
+  @Autowired UserRepository userRepository;
 
   /**
-   * The `filterChain` method in this Java code configures various security
-   * settings for an HTTP request,
-   * including authorization, exception handling, OAuth2 login, CSRF protection,
-   * and logout behavior.
-   * 
-   * @param http injected HttpSecurity object (injected by Spring framework)
-   *             //
+   * The `filterChain` method in this Java code configures various security settings for an HTTP
+   * request, including authorization, exception handling, OAuth2 login, CSRF protection, and logout
+   * behavior.
+   *
+   * @param http injected HttpSecurity object (injected by Spring framework) //
    */
   // https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#csrf-integration-javascript-spa
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http
-        .exceptionHandling(handling -> handling.authenticationEntryPoint(new Http403ForbiddenEntryPoint()))
+    http.exceptionHandling(
+            handling -> handling.authenticationEntryPoint(new Http403ForbiddenEntryPoint()))
         .oauth2Login(
-            oauth2 -> oauth2.userInfoEndpoint(userInfo -> userInfo.userAuthoritiesMapper(this.userAuthoritiesMapper())))
-        .csrf(csrf -> csrf
-            .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-            .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler()))
+            oauth2 ->
+                oauth2.userInfoEndpoint(
+                    userInfo -> userInfo.userAuthoritiesMapper(this.userAuthoritiesMapper())))
+        .csrf(
+            csrf ->
+                csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                    .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler()))
         .addFilterAfter(new CsrfCookieFilter(), BasicAuthenticationFilter.class)
         .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
-        .logout(logout -> logout.logoutRequestMatcher(new AntPathRequestMatcher("/logout")).logoutSuccessUrl("/"));
+        .logout(
+            logout ->
+                logout
+                    .logoutRequestMatcher(new AntPathRequestMatcher("/logout"))
+                    .logoutSuccessUrl("/"));
     return http.build();
   }
 
   /**
-   * The `webSecurityCustomizer` method is used to configure web security in Java,
-   * specifically ignoring requests
-   * to the "/h2-console/**" path.
+   * The `webSecurityCustomizer` method is used to configure web security in Java, specifically
+   * ignoring requests to the "/h2-console/**" path.
    */
   @Bean
   public WebSecurityCustomizer webSecurityCustomizer() {
@@ -105,40 +100,39 @@ public class SecurityConfig {
       Set<GrantedAuthority> mappedAuthorities = new HashSet<>();
       log.info("********** authorities={}", authorities);
 
-      authorities.forEach(authority -> {
-        log.info("********** authority={}", authority);
-        mappedAuthorities.add(authority);
-        if (authority instanceof OAuth2UserAuthority oauth2UserAuthority) {
-          Map<String, Object> userAttributes = oauth2UserAuthority.getAttributes();
-          log.info("********** userAttributes={}", userAttributes);
+      authorities.forEach(
+          authority -> {
+            log.info("********** authority={}", authority);
+            mappedAuthorities.add(authority);
+            if (authority instanceof OAuth2UserAuthority oauth2UserAuthority) {
+              Map<String, Object> userAttributes = oauth2UserAuthority.getAttributes();
+              log.info("********** userAttributes={}", userAttributes);
 
-          mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+              mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_USER"));
 
-          String email = (String) userAttributes.get("email");
-          if (getAdmin(email)) {
-            mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
-          }
+              String email = (String) userAttributes.get("email");
+              if (getAdmin(email)) {
+                mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+              }
 
-          if (getModerator(email)) {
-            mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_MODERATOR"));
-          }
+              if (getModerator(email)) {
+                mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_MODERATOR"));
+              }
 
-          if (email.endsWith("@ucsb.edu")) {
-            mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_MEMBER"));
-          }
-        }
-
-      });
+              if (email.endsWith("@ucsb.edu")) {
+                mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_MEMBER"));
+              }
+            }
+          });
       log.info("********** mappedAuthorities={}", mappedAuthorities);
       return mappedAuthorities;
     };
   }
 
   /**
-   * This method checks if the given email belongs to an admin user either from a
-   * predefined
-   * list or by querying the user repository.
-   * 
+   * This method checks if the given email belongs to an admin user either from a predefined list or
+   * by querying the user repository.
+   *
    * @param email email address of the user
    * @return whether the user with the given email is an admin
    */
@@ -151,13 +145,13 @@ public class SecurityConfig {
   }
 
   /**
-   * This method checks if the given email belongs to a moderator user
-   * by querying the user repository.
-   * 
+   * This method checks if the given email belongs to a moderator user by querying the user
+   * repository.
+   *
    * @param email email address of the user
    * @return whether the user with the given email is a moderator
    */
-  public boolean getModerator(String email){
+  public boolean getModerator(String email) {
     Optional<User> u = userRepository.findByEmail(email);
     return u.isPresent() && u.get().getModerator();
   }
@@ -167,7 +161,9 @@ final class SpaCsrfTokenRequestHandler extends CsrfTokenRequestAttributeHandler 
   private final CsrfTokenRequestHandler delegate = new XorCsrfTokenRequestAttributeHandler();
 
   @Override
-  public void handle(HttpServletRequest request, HttpServletResponse response,
+  public void handle(
+      HttpServletRequest request,
+      HttpServletResponse response,
       Supplier<CsrfToken> deferredCsrfToken) {
     /*
      * Always use XorCsrfTokenRequestAttributeHandler to provide BREACH protection
@@ -204,7 +200,8 @@ final class SpaCsrfTokenRequestHandler extends CsrfTokenRequestAttributeHandler 
 final class CsrfCookieFilter extends OncePerRequestFilter {
 
   @Override
-  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
     CsrfToken csrfToken = (CsrfToken) request.getAttribute("_csrf");
     // Render the token value to a cookie by causing the deferred token to be loaded

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ApiController.java
@@ -1,28 +1,23 @@
 package edu.ucsb.cs156.dining.controllers;
 
 import edu.ucsb.cs156.dining.errors.EntityNotFoundException;
-import org.springframework.beans.factory.annotation.Autowired;
-
 import edu.ucsb.cs156.dining.models.CurrentUser;
 import edu.ucsb.cs156.dining.services.CurrentUserService;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import java.util.Map;
-
-/**
- * This is an abstract class that provides common functionality for all API controllers.
- */
-
+/** This is an abstract class that provides common functionality for all API controllers. */
 @Slf4j
 public abstract class ApiController {
-  @Autowired
-  private CurrentUserService currentUserService;
+  @Autowired private CurrentUserService currentUserService;
 
   /**
    * This method returns the current user.
+   *
    * @return the current user
    */
   protected CurrentUser getCurrentUser() {
@@ -31,6 +26,7 @@ public abstract class ApiController {
 
   /**
    * This method returns a generic message.
+   *
    * @param message the message
    * @return a map with the message
    */
@@ -40,15 +36,15 @@ public abstract class ApiController {
 
   /**
    * This method handles the EntityNotFoundException.
+   *
    * @param e the exception
    * @return a map with the type and message of the exception
    */
-  @ExceptionHandler({ EntityNotFoundException.class })
+  @ExceptionHandler({EntityNotFoundException.class})
   @ResponseStatus(HttpStatus.NOT_FOUND)
   public Object handleGenericException(Throwable e) {
     return Map.of(
-      "type", e.getClass().getSimpleName(),
-      "message", e.getMessage()
-    );
+        "type", e.getClass().getSimpleName(),
+        "message", e.getMessage());
   }
 }

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/CSRFController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/CSRFController.java
@@ -1,22 +1,18 @@
 package edu.ucsb.cs156.dining.controllers;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-  
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
 /**
- * The CSRF controller is used to get a CSRF token. 
- * This is only enabled in the development profile, 
+ * The CSRF controller is used to get a CSRF token. This is only enabled in the development profile,
  * and is used to test APIs with Postman or swagger.ui/
- * 
- * For more information on CSRF, do a web search on "Cross-Site Request Forgery".
+ *
+ * <p>For more information on CSRF, do a web search on "Cross-Site Request Forgery".
  */
-
 @Profile("development")
 @Tag(name = "CSRF (enabled only in development; can be used with Postman to test APIs)")
 @RestController
@@ -24,10 +20,11 @@ public class CSRFController {
 
   /**
    * This method returns a CSRF token.
+   *
    * @param token the CSRF token, injected by Spring automatically
    * @return the CSRF token
    */
-  @Operation(summary= "Get a CSRF Token")
+  @Operation(summary = "Get a CSRF Token")
   @GetMapping("/csrf")
   public CsrfToken csrf(CsrfToken token) {
     return token;

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/DiningCommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/DiningCommonsController.java
@@ -1,22 +1,14 @@
 package edu.ucsb.cs156.dining.controllers;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.dining.models.DiningCommons;
-import edu.ucsb.cs156.dining.errors.EntityNotFoundException;
 import edu.ucsb.cs156.dining.services.DiningCommonsService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -33,7 +25,7 @@ public class DiningCommonsController extends ApiController /* implements Applica
   @GetMapping(value = "/all", produces = "application/json")
   public Iterable<DiningCommons> allDiningCommons() throws Exception {
     Iterable<DiningCommons> diningCommons = diningCommonsService.get();
-    
+
     return diningCommons;
   }
 }

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/FrontendController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/FrontendController.java
@@ -1,34 +1,31 @@
 package edu.ucsb.cs156.dining.controllers;
 
+import edu.ucsb.cs156.dining.services.wiremock.WiremockService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
-import edu.ucsb.cs156.dining.services.wiremock.WiremockService;
-
 /**
  * The FrontendController is used to serve the frontend of the application.
- * 
- * This is only enabled in the production profile, and is used to serve the frontend of the application.
- * For development, see the FrontendProxyController.
- * 
+ *
+ * <p>This is only enabled in the production profile, and is used to serve the frontend of the
+ * application. For development, see the FrontendProxyController.
+ *
  * @see edu.ucsb.cs156.dining.controllers.FrontendProxyController
  */
-
 @Profile("!development")
 @Controller
 public class FrontendController {
 
-  @Autowired
-  WiremockService wiremockService;
-  
+  @Autowired WiremockService wiremockService;
+
   /**
    * Serve home page of application
+   *
    * @return the home page (via index.html)
    */
-
   @GetMapping("/**/{path:[^\\.]*}")
   public String index() {
     return "forward:/index.html";
@@ -36,12 +33,11 @@ public class FrontendController {
 
   /**
    * When not in development, the CSRF endpoint is not used, so return 404
+   *
    * @return response entity with 404 return code (not found)
    */
-  
   @GetMapping("/csrf")
   public ResponseEntity<String> csrf() {
     return ResponseEntity.notFound().build();
   }
-
 }

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/FrontendProxyController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/FrontendProxyController.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.dining.controllers;
 
+import edu.ucsb.cs156.dining.services.wiremock.WiremockService;
+import java.net.ConnectException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.context.annotation.Profile;
@@ -8,45 +10,40 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.ResourceAccessException;
 
-import edu.ucsb.cs156.dining.services.wiremock.WiremockService;
-
-import java.net.ConnectException;
-
 /**
  * The FrontendProxyController is used to proxy requests to the frontend of the application.
- * 
- * This is only used in development where we have a separate frontend server process
- * listening on port 3000.
- * 
- * For production, see the FrontendController.
- * 
+ *
+ * <p>This is only used in development where we have a separate frontend server process listening on
+ * port 3000.
+ *
+ * <p>For production, see the FrontendController.
+ *
  * @see edu.ucsb.cs156.dining.controllers.FrontendController
  */
-
 @Profile("development")
 @RestController
 public class FrontendProxyController {
 
-  @Autowired
-  WiremockService wiremockService;
-  
-  /**
-   * This method proxies requests to the frontend server.  It is only used in development.
-   * The regular expression is used to exclude the paths that should NOT be proxied to the
-   * frontend server, such as the endpoints for the api, oauth2, and swagger-ui.
-   * 
-   * @param proxy the proxy exchange, injected by Spring automatically
-   * @return response entity with the response from the frontend server, or a response entity with instructions in case the frontend server cannot be reached.
-   */
+  @Autowired WiremockService wiremockService;
 
+  /**
+   * This method proxies requests to the frontend server. It is only used in development. The
+   * regular expression is used to exclude the paths that should NOT be proxied to the frontend
+   * server, such as the endpoints for the api, oauth2, and swagger-ui.
+   *
+   * @param proxy the proxy exchange, injected by Spring automatically
+   * @return response entity with the response from the frontend server, or a response entity with
+   *     instructions in case the frontend server cannot be reached.
+   */
   @GetMapping({"/", "/{path:^(?!api|oauth2|swagger-ui|h2-console).*}/**"})
-  public ResponseEntity<?> proxy(ProxyExchange<byte []> proxy) {
+  public ResponseEntity<?> proxy(ProxyExchange<byte[]> proxy) {
     String path = proxy.path("/");
     try {
       return proxy.uri("http://localhost:3000/" + path).get();
     } catch (ResourceAccessException e) {
       if (e.getCause() instanceof ConnectException) {
-        String instructions = """
+        String instructions =
+            """
                 <p>Failed to connect to the frontend server...</p>
                 <p>On Dokku, be sure that <code>PRODUCTION</code> is defined.</p>
                 <p>On localhost, open a second terminal window, cd into <code>frontend</code> and type: <code>npm install; npm start</code></p>

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
@@ -1,28 +1,25 @@
 package edu.ucsb.cs156.dining.controllers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.ucsb.cs156.dining.entities.MenuItem;
 import edu.ucsb.cs156.dining.entities.Review;
 import edu.ucsb.cs156.dining.entities.User;
 import edu.ucsb.cs156.dining.errors.EntityNotFoundException;
 import edu.ucsb.cs156.dining.models.CurrentUser;
 import edu.ucsb.cs156.dining.models.EditedReview;
-import edu.ucsb.cs156.dining.models.Entree;
 import edu.ucsb.cs156.dining.repositories.MenuItemRepository;
 import edu.ucsb.cs156.dining.repositories.ReviewRepository;
 import edu.ucsb.cs156.dining.statuses.ModerationStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.extern.slf4j.Slf4j;
-import com.fasterxml.jackson.core.JsonProcessingException;
-
+import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -35,188 +32,193 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 
-import com.nimbusds.openid.connect.sdk.claims.UserInfo;
-
-import jakarta.validation.Valid;
-
-/**
- * This is a REST controller for Reviews
- */
-
+/** This is a REST controller for Reviews */
 @Tag(name = "Review")
 @RequestMapping("/api/reviews")
 @RestController
 @Slf4j
 public class ReviewController extends ApiController {
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<Map<String, String>> handleValidationExceptions(IllegalArgumentException ex) {
-        Map<String, String> errors = new HashMap<>();
-        errors.put("error", ex.getMessage());
-        return ResponseEntity.badRequest().body(errors);
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<Map<String, String>> handleValidationExceptions(
+      IllegalArgumentException ex) {
+    Map<String, String> errors = new HashMap<>();
+    errors.put("error", ex.getMessage());
+    return ResponseEntity.badRequest().body(errors);
+  }
+
+  @Autowired ReviewRepository reviewRepository;
+
+  @Autowired MenuItemRepository menuItemRepository;
+
+  /**
+   * This method returns a list of all Reviews.
+   *
+   * @return a list of all Reviews
+   */
+  @Operation(summary = "List all Reviews")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @GetMapping("/all")
+  public Iterable<Review> allReviews() {
+    log.info("Attempting to log all reviews");
+    Iterable<Review> reviews = reviewRepository.findAll();
+    log.info("all reviews found, ", reviews);
+    return reviews;
+  }
+
+  /**
+   * This method allows a user to submit a review
+   *
+   * @return message that says an review was added to the database
+   * @param itemId id of the item
+   * @param dateItemServed localDataTime All others params must not be parameters and instead
+   *     derived from data sources that are dynamic (Date), or set to be null or some other
+   *     signifier
+   */
+  @Operation(summary = "Create a new review")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @PostMapping("/post")
+  public Review postReview(
+      @Parameter(name = "itemId") @RequestParam long itemId,
+      @Parameter(description = "Comments by the reviewer, can be blank")
+          @RequestParam(required = false)
+          String reviewerComments,
+      @Parameter(name = "itemsStars") @RequestParam Long itemsStars,
+      @Parameter(
+              name = "dateItemServed",
+              description =
+                  "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)")
+          @RequestParam("dateItemServed")
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          LocalDateTime dateItemServed) // For
+      throws JsonProcessingException {
+    LocalDateTime now = LocalDateTime.now();
+    Review review = new Review();
+    review.setDateItemServed(dateItemServed);
+
+    // Ensures content of truly empty and sets to null if so
+    if (reviewerComments != null && !reviewerComments.trim().isEmpty()) {
+      review.setReviewerComments(reviewerComments);
     }
 
-    @Autowired
-    ReviewRepository reviewRepository;
-
-    @Autowired
-    MenuItemRepository menuItemRepository;
-
-    /**
-     * This method returns a list of all Reviews.
-     * 
-     * @return a list of all Reviews
-     */
-    @Operation(summary = "List all Reviews")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @GetMapping("/all")
-    public Iterable<Review> allReviews() {
-        log.info("Attempting to log all reviews");
-        Iterable<Review> reviews = reviewRepository.findAll();
-        log.info("all reviews found, ", reviews);
-        return reviews;
+    // Ensure user inputs rating 1-5
+    if (itemsStars < 1 || itemsStars > 5) {
+      throw new IllegalArgumentException("Items stars must be between 1 and 5.");
     }
 
-    /**
-     * This method allows a user to submit a review
-     * 
-     * @return message that says an review was added to the database
-     * @param itemId         id of the item
-     * @param dateItemServed localDataTime
-     *                       All others params must not be parameters and instead
-     *                       derived from data sources that are dynamic (Date), or
-     *                       set to be null or some other signifier
-     */
-    @Operation(summary = "Create a new review")
-    @PreAuthorize("hasRole('ROLE_USER')")
-    @PostMapping("/post")
-    public Review postReview(
-            @Parameter(name = "itemId") @RequestParam long itemId,
-            @Parameter(description = "Comments by the reviewer, can be blank") @RequestParam(required = false) String reviewerComments,
-            @Parameter(name = "itemsStars") @RequestParam Long itemsStars,
-            @Parameter(name = "dateItemServed", description = "date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS; see https://en.wikipedia.org/wiki/ISO_8601)") @RequestParam("dateItemServed") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateItemServed) // For
-            throws JsonProcessingException {
-        LocalDateTime now = LocalDateTime.now();
-        Review review = new Review();
-        review.setDateItemServed(dateItemServed);
+    review.setItemsStars(itemsStars);
 
-        // Ensures content of truly empty and sets to null if so
-        if (reviewerComments != null && !reviewerComments.trim().isEmpty()) {
-            review.setReviewerComments(reviewerComments);
-        }
+    MenuItem reviewedItem =
+        menuItemRepository
+            .findById(itemId)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItem.class, itemId));
 
-        // Ensure user inputs rating 1-5
-        if (itemsStars < 1 || itemsStars > 5) {
-            throw new IllegalArgumentException("Items stars must be between 1 and 5.");
-        }
-
-        review.setItemsStars(itemsStars);
-
-        MenuItem reviewedItem = menuItemRepository.findById(itemId).orElseThrow(
-                () -> new EntityNotFoundException(MenuItem.class, itemId)
-        );
-
-        if (review.getReviewerComments() == null) {
-            review.setStatus(ModerationStatus.APPROVED);
-        }
-
-        review.setItem(reviewedItem);
-        CurrentUser user = getCurrentUser();
-        review.setReviewer(user.getUser());
-        log.info("reviews={}", review);
-        review = reviewRepository.save(review);
-        return review;
+    if (review.getReviewerComments() == null) {
+      review.setStatus(ModerationStatus.APPROVED);
     }
 
-    /**
-     * This method allows a user to get a list of reviews that they have previously made.
-     * Only user can only get a list of their own reviews, and you cant request another persons reviews
-     * @return a list of reviews sent by a given user
-     */
-    @Operation(summary = "Get all reviews a user has sent: only callable by the user")
-    @PreAuthorize("hasRole('ROLE_USER')")
-    @GetMapping("/userReviews")
-    public Iterable<Review> get_all_review_by_user_id(){
-        CurrentUser user = getCurrentUser();
-        Iterable<Review> reviews = reviewRepository.findByReviewer(user.getUser());
-        return reviews;
+    review.setItem(reviewedItem);
+    CurrentUser user = getCurrentUser();
+    review.setReviewer(user.getUser());
+    log.info("reviews={}", review);
+    review = reviewRepository.save(review);
+    return review;
+  }
+
+  /**
+   * This method allows a user to get a list of reviews that they have previously made. Only user
+   * can only get a list of their own reviews, and you cant request another persons reviews
+   *
+   * @return a list of reviews sent by a given user
+   */
+  @Operation(summary = "Get all reviews a user has sent: only callable by the user")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/userReviews")
+  public Iterable<Review> get_all_review_by_user_id() {
+    CurrentUser user = getCurrentUser();
+    Iterable<Review> reviews = reviewRepository.findByReviewer(user.getUser());
+    return reviews;
+  }
+
+  @Operation(summary = "Edit a review")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @PutMapping("/reviewer")
+  public Review editReview(@Parameter Long id, @RequestBody @Valid EditedReview incoming) {
+
+    Review oldReview =
+        reviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(Review.class, id));
+    User current = getCurrentUser().getUser();
+    if (current.getId() != oldReview.getReviewer().getId()) {
+      throw new AccessDeniedException("No permission to edit review");
     }
 
-    @Operation(summary = "Edit a review")
-    @PreAuthorize("hasRole('ROLE_USER')")
-    @PutMapping("/reviewer")
-    public Review editReview(@Parameter Long id, @RequestBody @Valid EditedReview incoming) {
-
-        Review oldReview = reviewRepository.findById(id).orElseThrow(
-                () -> new EntityNotFoundException(Review.class, id)
-        );
-        User current = getCurrentUser().getUser();
-        if(current.getId() != oldReview.getReviewer().getId()) {
-            throw new AccessDeniedException("No permission to edit review");
-        }
-
-        if(incoming.getItemStars() < 1 || incoming.getItemStars() > 5) {
-            throw new IllegalArgumentException("Items stars must be between 1 and 5.");
-        }else{
-            oldReview.setItemsStars(incoming.getItemStars());
-        }
-
-        if (incoming.getReviewerComments() != null &&!incoming.getReviewerComments().trim().isEmpty()) {
-            oldReview.setReviewerComments(incoming.getReviewerComments());
-            oldReview.setStatus(ModerationStatus.AWAITING_REVIEW);
-        }else{
-            oldReview.setReviewerComments(null);
-            oldReview.setStatus(ModerationStatus.APPROVED);
-        }
-
-        oldReview.setDateItemServed(incoming.getDateItemServed());
-
-        oldReview.setModeratorComments(null);
-
-        Review review = reviewRepository.save(oldReview);
-
-        return review;
+    if (incoming.getItemStars() < 1 || incoming.getItemStars() > 5) {
+      throw new IllegalArgumentException("Items stars must be between 1 and 5.");
+    } else {
+      oldReview.setItemsStars(incoming.getItemStars());
     }
 
-    @Operation(summary = "Delete a review")
-    @PreAuthorize("hasRole('ROLE_USER')")
-    @DeleteMapping("/reviewer")
-    public Object deleteReview(@Parameter Long id) {
-        Review review = reviewRepository.findById(id).orElseThrow(
-                () -> new EntityNotFoundException(Review.class, id)
-        );
-
-        User current = getCurrentUser().getUser();
-        if(current.getId() != review.getReviewer().getId() && !current.getAdmin()) {
-            throw new AccessDeniedException("No permission to delete review");
-        }
-
-        reviewRepository.delete(review);
-        return genericMessage("Review with id %s deleted".formatted(id));
+    if (incoming.getReviewerComments() != null
+        && !incoming.getReviewerComments().trim().isEmpty()) {
+      oldReview.setReviewerComments(incoming.getReviewerComments());
+      oldReview.setStatus(ModerationStatus.AWAITING_REVIEW);
+    } else {
+      oldReview.setReviewerComments(null);
+      oldReview.setStatus(ModerationStatus.APPROVED);
     }
 
-    @Operation(summary = "Moderate a review")
-    @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_MODERATOR')")
-    @PutMapping("/moderate")
-    public Review moderateReview(@Parameter Long id, @Parameter ModerationStatus status, @Parameter String moderatorComments) {
-        Review review = reviewRepository.findById(id).orElseThrow(
-                () -> new EntityNotFoundException(Review.class, id)
-        );
+    oldReview.setDateItemServed(incoming.getDateItemServed());
 
-        review.setModeratorComments(moderatorComments);
-        review.setStatus(status);
+    oldReview.setModeratorComments(null);
 
-        review = reviewRepository.save(review);
-        return review;
+    Review review = reviewRepository.save(oldReview);
+
+    return review;
+  }
+
+  @Operation(summary = "Delete a review")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @DeleteMapping("/reviewer")
+  public Object deleteReview(@Parameter Long id) {
+    Review review =
+        reviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(Review.class, id));
+
+    User current = getCurrentUser().getUser();
+    if (current.getId() != review.getReviewer().getId() && !current.getAdmin()) {
+      throw new AccessDeniedException("No permission to delete review");
     }
 
-    @Operation(summary = "See reviews that need moderation")
-    @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_MODERATOR')")
-    @GetMapping("/needsmoderation")
-    public Iterable<Review> needsmoderation() {
-        Iterable<Review> reviewsList = reviewRepository.findByStatus(ModerationStatus.AWAITING_REVIEW);
-        return reviewsList;
-    }
+    reviewRepository.delete(review);
+    return genericMessage("Review with id %s deleted".formatted(id));
+  }
+
+  @Operation(summary = "Moderate a review")
+  @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_MODERATOR')")
+  @PutMapping("/moderate")
+  public Review moderateReview(
+      @Parameter Long id, @Parameter ModerationStatus status, @Parameter String moderatorComments) {
+    Review review =
+        reviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(Review.class, id));
+
+    review.setModeratorComments(moderatorComments);
+    review.setStatus(status);
+
+    review = reviewRepository.save(review);
+    return review;
+  }
+
+  @Operation(summary = "See reviews that need moderation")
+  @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_MODERATOR')")
+  @GetMapping("/needsmoderation")
+  public Iterable<Review> needsmoderation() {
+    Iterable<Review> reviewsList = reviewRepository.findByStatus(ModerationStatus.AWAITING_REVIEW);
+    return reviewsList;
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/SystemInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/SystemInfoController.java
@@ -4,9 +4,7 @@ import edu.ucsb.cs156.dining.models.SystemInfo;
 import edu.ucsb.cs156.dining.services.SystemInfoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,33 +12,29 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * This is a REST controller for getting information about the system.
  *
- * It allows frontend access to some of the global values set in the
- * backend of the application, some of which are set by environment
- * variables.
- * 
- * For more information see the SystemInfoService and SystemInfo classes.
- * 
+ * <p>It allows frontend access to some of the global values set in the backend of the application,
+ * some of which are set by environment variables.
+ *
+ * <p>For more information see the SystemInfoService and SystemInfo classes.
+ *
  * @see edu.ucsb.cs156.dining.services.SystemInfoService
  * @see edu.ucsb.cs156.dining.models.SystemInfo
  */
-
 @Tag(name = "System Information")
 @RequestMapping("/api/systemInfo")
 @RestController
 public class SystemInfoController extends ApiController {
 
-    @Autowired
-    private SystemInfoService systemInfoService;
+  @Autowired private SystemInfoService systemInfoService;
 
-    /**
-     * This method returns the system information.
-     * @return the system information
-     */
-
-    @Operation(summary = "Get global information about the application")
-    @GetMapping("")
-    public SystemInfo getSystemInfo() {
-        return systemInfoService.getSystemInfo();
-    }
-
+  /**
+   * This method returns the system information.
+   *
+   * @return the system information
+   */
+  @Operation(summary = "Get global information about the application")
+  @GetMapping("")
+  public SystemInfo getSystemInfo() {
+    return systemInfoService.getSystemInfo();
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuController.java
@@ -1,31 +1,16 @@
 package edu.ucsb.cs156.dining.controllers;
 
 import edu.ucsb.cs156.dining.services.UCSBDiningMenuService;
-import edu.ucsb.cs156.dining.errors.EntityNotFoundException;
-import edu.ucsb.cs156.dining.repositories.UserRepository;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.http.ResponseEntity;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import org.springframework.format.annotation.DateTimeFormat;
-import java.util.List;
-
-import jakarta.validation.Valid;
 
 @Tag(name = "UCSBDiningMenuController")
 @RestController
@@ -38,11 +23,13 @@ public class UCSBDiningMenuController extends ApiController {
   @Operation(summary = "Get list of meals serving in given dining common on given date")
   @GetMapping(value = "/{date-time}/{dining-commons-code}", produces = "application/json")
   public ResponseEntity<String> menutimes(
-      @Parameter(description= "date (in iso format, e.g. YYYY-mm-dd) or date-time (in iso format e.g. YYYY-mm-ddTHH:MM:SS)") 
-      @PathVariable("date-time") String datetime,
-      @PathVariable("dining-commons-code") String diningcommoncode
-  )
-    throws Exception {
+      @Parameter(
+              description =
+                  "date (in iso format, e.g. YYYY-mm-dd) or date-time (in iso format e.g. YYYY-mm-ddTHH:MM:SS)")
+          @PathVariable("date-time")
+          String datetime,
+      @PathVariable("dining-commons-code") String diningcommoncode)
+      throws Exception {
 
     String body = ucsbDiningMenuService.getJSON(datetime, diningcommoncode);
 

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsController.java
@@ -1,32 +1,24 @@
 package edu.ucsb.cs156.dining.controllers;
 
-import edu.ucsb.cs156.dining.services.UCSBDiningMenuItemsService;
-import edu.ucsb.cs156.dining.models.Entree;
 import edu.ucsb.cs156.dining.entities.MenuItem;
-import edu.ucsb.cs156.dining.repositories.MenuItemRepository;
-import java.util.Optional;
-import java.util.ArrayList;
-
 import edu.ucsb.cs156.dining.errors.EntityNotFoundException;
-
+import edu.ucsb.cs156.dining.models.Entree;
+import edu.ucsb.cs156.dining.repositories.MenuItemRepository;
+import edu.ucsb.cs156.dining.services.UCSBDiningMenuItemsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.http.ResponseEntity;
-
+import java.util.ArrayList;
 import java.util.List;
-
-import jakarta.validation.Valid;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "UCSBDiningMenuItems")
 @RestController
@@ -35,36 +27,41 @@ import jakarta.validation.Valid;
 public class UCSBDiningMenuItemsController extends ApiController {
 
   @Autowired UCSBDiningMenuItemsService ucsbDiningMenuItemsService;
-  
-  @Autowired
-  MenuItemRepository menuItemRepository;
+
+  @Autowired MenuItemRepository menuItemRepository;
 
   @Operation(summary = "Get list of entrees being served at given meal, dining common, and day")
-  @GetMapping(value = "/{date-time}/{dining-commons-code}/{meal-code}", produces = "application/json")
+  @GetMapping(
+      value = "/{date-time}/{dining-commons-code}/{meal-code}",
+      produces = "application/json")
   public ResponseEntity<List<MenuItem>> get_menu_items(
-      @Parameter(description= "date (in iso format, e.g. YYYY-mm-dd) or date-time (in iso format e.g. YYYY-mm-ddTHH:MM:SS)") 
-      @PathVariable("date-time") String datetime,
+      @Parameter(
+              description =
+                  "date (in iso format, e.g. YYYY-mm-dd) or date-time (in iso format e.g. YYYY-mm-ddTHH:MM:SS)")
+          @PathVariable("date-time")
+          String datetime,
       @PathVariable("dining-commons-code") String diningcommoncode,
-      @PathVariable("meal-code") String mealcode
-  )
-    throws Exception {
+      @PathVariable("meal-code") String mealcode)
+      throws Exception {
 
     List<Entree> body = ucsbDiningMenuItemsService.get(datetime, diningcommoncode, mealcode);
 
     List<MenuItem> menuitems = new ArrayList<>();
 
     for (Entree entree : body) {
-        Optional<MenuItem> exists = menuItemRepository.findByDiningCommonsCodeAndMealCodeAndNameAndStation(diningcommoncode, mealcode, entree.getName(), entree.getStation());
+      Optional<MenuItem> exists =
+          menuItemRepository.findByDiningCommonsCodeAndMealCodeAndNameAndStation(
+              diningcommoncode, mealcode, entree.getName(), entree.getStation());
 
-        MenuItem newMenuItem = exists.orElse(new MenuItem());
-          // MenuItem newMenuItem = new MenuItem();
-          newMenuItem.setDiningCommonsCode(diningcommoncode);
-          newMenuItem.setMealCode(mealcode);
-          newMenuItem.setName(entree.getName());
-          newMenuItem.setStation(entree.getStation());
+      MenuItem newMenuItem = exists.orElse(new MenuItem());
+      // MenuItem newMenuItem = new MenuItem();
+      newMenuItem.setDiningCommonsCode(diningcommoncode);
+      newMenuItem.setMealCode(mealcode);
+      newMenuItem.setName(entree.getName());
+      newMenuItem.setStation(entree.getStation());
 
-          menuItemRepository.save(newMenuItem);
-          menuitems.add(newMenuItem);
+      menuItemRepository.save(newMenuItem);
+      menuitems.add(newMenuItem);
     }
 
     return ResponseEntity.ok().body(menuitems);
@@ -73,8 +70,7 @@ public class UCSBDiningMenuItemsController extends ApiController {
   @Operation(summary = "Get a single menu item by ID")
   @GetMapping(value = "/menuitem", produces = "application/json")
   public ResponseEntity<MenuItem> get_menu_item_by_id(
-      @Parameter(description = "ID of the menu item") @RequestParam long id
-  ) throws Exception {
+      @Parameter(description = "ID of the menu item") @RequestParam long id) throws Exception {
     Optional<MenuItem> menuItem = menuItemRepository.findById(id);
     if (menuItem.isEmpty()) {
       throw new EntityNotFoundException(MenuItem.class, id);

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/UserInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/UserInfoController.java
@@ -1,33 +1,25 @@
 package edu.ucsb.cs156.dining.controllers;
 
 import edu.ucsb.cs156.dining.models.CurrentUser;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
-/**
- * This is a REST controller for getting information about the current user.
- */
-
-@Tag(name="Current User Information")
+/** This is a REST controller for getting information about the current user. */
+@Tag(name = "Current User Information")
 @RequestMapping("/api/currentUser")
 @RestController
 public class UserInfoController extends ApiController {
- 
+
   /**
    * This method returns the current user.
+   *
    * @return the current user
    */
-
-  @Operation(summary= "Get information about current user")
+  @Operation(summary = "Get information about current user")
   @PreAuthorize("hasRole('ROLE_USER')")
   @GetMapping("")
   public CurrentUser getCurrentUser() {

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/UsersController.java
@@ -2,179 +2,168 @@ package edu.ucsb.cs156.dining.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import edu.ucsb.cs156.dining.statuses.ModerationStatus;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import edu.ucsb.cs156.dining.entities.User;
-import edu.ucsb.cs156.dining.repositories.UserRepository;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
-
-import edu.ucsb.cs156.dining.models.CurrentUser;
 import edu.ucsb.cs156.dining.entities.User;
 import edu.ucsb.cs156.dining.errors.EntityNotFoundException;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.server.ResponseStatusException;
-import java.util.List;
-
+import edu.ucsb.cs156.dining.models.CurrentUser;
+import edu.ucsb.cs156.dining.repositories.UserRepository;
+import edu.ucsb.cs156.dining.statuses.ModerationStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * This is a REST controller for getting information about the users.
- * 
- * These endpoints are only accessible to users with the role "ROLE_ADMIN".
+ *
+ * <p>These endpoints are only accessible to users with the role "ROLE_ADMIN".
  */
-
-@Tag(name="User information (admin only)")
+@Tag(name = "User information (admin only)")
 @RequestMapping("/api")
 @RestController
 public class UsersController extends ApiController {
 
-    @Value("${app.admin.emails}")
-    private final List<String> adminEmails = new ArrayList<>();
+  @Value("${app.admin.emails}")
+  private final List<String> adminEmails = new ArrayList<>();
 
-    @Autowired
-    UserRepository userRepository;
+  @Autowired UserRepository userRepository;
 
-    @Autowired
-    ObjectMapper mapper;
+  @Autowired ObjectMapper mapper;
 
-    /**
-     * This method returns a list of all users.  Accessible only to users with the role "ROLE_ADMIN".
-     * @return a list of all users
-     * @throws JsonProcessingException if there is an error processing the JSON
-     */
-    @Operation(summary= "Get a list of all users")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @GetMapping("/admin/users")
-    public ResponseEntity<String> users()
-            throws JsonProcessingException {
+  /**
+   * This method returns a list of all users. Accessible only to users with the role "ROLE_ADMIN".
+   *
+   * @return a list of all users
+   * @throws JsonProcessingException if there is an error processing the JSON
+   */
+  @Operation(summary = "Get a list of all users")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @GetMapping("/admin/users")
+  public ResponseEntity<String> users() throws JsonProcessingException {
 
+    Iterable<User> users = userRepository.findAll();
+    String body = mapper.writeValueAsString(users);
+    return ResponseEntity.ok().body(body);
+  }
 
-        Iterable<User> users = userRepository.findAll();
-        String body = mapper.writeValueAsString(users);
-        return ResponseEntity.ok().body(body);
+  /**
+   * This method returns list of all users with a proposed alias.
+   *
+   * @return a list of users with a proposed alias
+   * @throws JsonProcessingException if there is an error processing the JSON
+   */
+  @Operation(summary = "Get a list of all users with a proposed alias")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @GetMapping("/admin/usersWithProposedAlias")
+  public ResponseEntity<String> getUsersWithProposedAlias() throws JsonProcessingException {
+    Iterable<User> users = userRepository.findByProposedAliasNotNull();
+    String body = mapper.writeValueAsString(users);
+    return ResponseEntity.ok().body(body);
+  }
+
+  /**
+   * This method allows the user to update their alias.
+   *
+   * @param proposedAlias the new alias
+   * @return the updated user
+   */
+  @Operation(summary = "Update proposed alias of the current user")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @PostMapping("/currentUser/updateAlias")
+  public ResponseEntity<User> updateProposedAlias(@RequestParam String proposedAlias) {
+    CurrentUser currentUser = super.getCurrentUser();
+    User user = currentUser.getUser();
+
+    if (userRepository.findByAlias(proposedAlias).isPresent()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Alias already in use.");
     }
 
-    /**
-     * This method returns list of all users with a proposed alias.
-     * @return a list of users with a proposed alias
-     * @throws JsonProcessingException if there is an error processing the JSON
-     */
-    @Operation(summary = "Get a list of all users with a proposed alias")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @GetMapping("/admin/usersWithProposedAlias")
-    public ResponseEntity<String> getUsersWithProposedAlias()
-            throws JsonProcessingException {
-        Iterable<User> users = userRepository.findByProposedAliasNotNull();
-        String body = mapper.writeValueAsString(users);
-        return ResponseEntity.ok().body(body);
+    user.setProposedAlias(proposedAlias);
+    user.setStatus(ModerationStatus.AWAITING_REVIEW);
+    User savedUser = userRepository.save(user);
+
+    return ResponseEntity.ok(savedUser);
+  }
+
+  /**
+   * This method allows an admin to update the moderation status of a user's alias.
+   *
+   * @param id the id of the user to update
+   * @param approved the new moderation status
+   * @return the updated user
+   */
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("/currentUser/updateAliasModeration")
+  public User updateAliasModeration(@RequestParam long id, @RequestParam Boolean approved) {
+
+    User user =
+        userRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+    if (approved) {
+      user.setAlias(user.getProposedAlias());
+      user.setStatus(ModerationStatus.APPROVED);
+      user.setDateApproved(LocalDate.now());
+      user.setProposedAlias(null);
+    } else {
+      user.setStatus(ModerationStatus.REJECTED);
+      user.setProposedAlias(null);
     }
 
-    /**
-     * This method allows the user to update their alias.
-     * @param proposedAlias the new alias
-     * @return the updated user
-     */
-    @Operation(summary = "Update proposed alias of the current user")
-    @PreAuthorize("hasRole('ROLE_USER')")
-    @PostMapping("/currentUser/updateAlias")
-    public ResponseEntity<User> updateProposedAlias(@RequestParam String proposedAlias) {
-        CurrentUser currentUser = super.getCurrentUser();
-        User user = currentUser.getUser();
+    userRepository.save(user);
 
-        if (userRepository.findByAlias(proposedAlias).isPresent()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Alias already in use.");
-        }
-    
-        user.setProposedAlias(proposedAlias);
-        user.setStatus(ModerationStatus.AWAITING_REVIEW);
-        User savedUser = userRepository.save(user);
-    
-        return ResponseEntity.ok(savedUser);
-    }
-    
-    /**
-     * This method allows an admin to update the moderation status of a user's alias.
-     * @param id the id of the user to update
-     * @param approved the new moderation status 
-     * @return the updated user
-     */
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PutMapping("/currentUser/updateAliasModeration")
-    public User updateAliasModeration(
-            @RequestParam long id, 
-            @RequestParam Boolean approved) {
-        
-        User user = userRepository.findById(id)
-            .orElseThrow(() -> new EntityNotFoundException(User.class, id));
-        
+    return user;
+  }
 
-        if (approved) {
-            user.setAlias(user.getProposedAlias());  
-            user.setStatus(ModerationStatus.APPROVED);
-            user.setDateApproved(LocalDate.now());
-            user.setProposedAlias(null);
-        } else {
-            user.setStatus(ModerationStatus.REJECTED);
-            user.setProposedAlias(null);
-        }
-        
-        userRepository.save(user);
+  /**
+   * This method allows an admin to toggle the admin status of a user. Will not toggle status of
+   * admin in adminEmails.
+   *
+   * @param id the id of the user to toggle
+   * @return the updated user
+   */
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("/admin/toggleAdmin")
+  public User toggleAdminStatus(@RequestParam long id) {
 
-        return user;
+    User user =
+        userRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+    if (!adminEmails.contains(user.getEmail())) {
+      user.setAdmin(!user.getAdmin());
     }
 
-    /**
-     * This method allows an admin to toggle the admin status of a user.
-     * Will not toggle status of admin in adminEmails.
-     * @param id the id of the user to toggle
-     * @return the updated user
-     */
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PutMapping("/admin/toggleAdmin")
-    public User toggleAdminStatus(@RequestParam long id) {
-        
-        User user = userRepository.findById(id)
-            .orElseThrow(() -> new EntityNotFoundException(User.class, id));
-        
-        if(!adminEmails.contains(user.getEmail())) {
-            user.setAdmin(!user.getAdmin());
-        }
-        
-        userRepository.save(user);
+    userRepository.save(user);
 
-        return user;
-    }
+    return user;
+  }
 
-    /**
-     * This method allows an admin to toggle the moderator status of a user.
-     * @param id the id of the user to toggle
-     * @return the updated user
-     */
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PutMapping("/admin/toggleModerator")
-    public User toggleModeratorStatus(
-            @RequestParam long id) {
-        
-        User user = userRepository.findById(id)
-            .orElseThrow(() -> new EntityNotFoundException(User.class, id));
-        
-        user.setModerator(!user.getModerator());
-        
-        userRepository.save(user);
+  /**
+   * This method allows an admin to toggle the moderator status of a user.
+   *
+   * @param id the id of the user to toggle
+   * @return the updated user
+   */
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("/admin/toggleModerator")
+  public User toggleModeratorStatus(@RequestParam long id) {
 
-        return user;
-    }
+    User user =
+        userRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+    user.setModerator(!user.getModerator());
+
+    userRepository.save(user);
+
+    return user;
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/dining/entities/MenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/dining/entities/MenuItem.java
@@ -2,19 +2,16 @@ package edu.ucsb.cs156.dining.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
+import java.util.List;
 import lombok.*;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
-import java.util.List;
-
-
 /**
  * This is a JPA entity that represents a MenuItem
  *
- * A MenuItem represents an actual menu item in a dining commons at UCSB
+ * <p>A MenuItem represents an actual menu item in a dining commons at UCSB
  */
-
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/edu/ucsb/cs156/dining/entities/Review.java
+++ b/src/main/java/edu/ucsb/cs156/dining/entities/Review.java
@@ -4,6 +4,7 @@ import edu.ucsb.cs156.dining.statuses.ModerationStatus;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,9 +13,6 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
-
-
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -22,44 +20,43 @@ import java.time.LocalDateTime;
 @Entity(name = "reviews")
 @EntityListeners(AuditingEntityListener.class)
 public class Review {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
 
-    @Column(columnDefinition = "VARCHAR(255) DEFAULT NULL")
-    private String reviewerComments;
+  @Column(columnDefinition = "VARCHAR(255) DEFAULT NULL")
+  private String reviewerComments;
 
-    @Column(columnDefinition = "BIGINT DEFAULT NULL")
-    @Min(1)
-    @Max(5)
-    private Long itemsStars;
+  @Column(columnDefinition = "BIGINT DEFAULT NULL")
+  @Min(1)
+  @Max(5)
+  private Long itemsStars;
 
-    @Column(nullable = false)
-    private LocalDateTime dateItemServed;
+  @Column(nullable = false)
+  private LocalDateTime dateItemServed;
 
-    @Column(nullable = false, columnDefinition = "VARCHAR(255) DEFAULT 'AWAITING_REVIEW'")
-    @Enumerated(EnumType.STRING)
-    @Builder.Default
-    private ModerationStatus status = ModerationStatus.AWAITING_REVIEW;
+  @Column(nullable = false, columnDefinition = "VARCHAR(255) DEFAULT 'AWAITING_REVIEW'")
+  @Enumerated(EnumType.STRING)
+  @Builder.Default
+  private ModerationStatus status = ModerationStatus.AWAITING_REVIEW;
 
-    @Column(columnDefinition = "VARCHAR(255) DEFAULT NULL")
-    private String userIdModerator;
+  @Column(columnDefinition = "VARCHAR(255) DEFAULT NULL")
+  private String userIdModerator;
 
-    @Column(columnDefinition = "VARCHAR(255) DEFAULT NULL")
-    private String moderatorComments;
+  @Column(columnDefinition = "VARCHAR(255) DEFAULT NULL")
+  private String moderatorComments;
 
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime dateCreated;
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime dateCreated;
 
-    @LastModifiedDate
-    private LocalDateTime dateEdited;
+  @LastModifiedDate private LocalDateTime dateEdited;
 
-    @ManyToOne
-    @JoinColumn(name = "item_id", nullable = false)
-    private MenuItem item;
+  @ManyToOne
+  @JoinColumn(name = "item_id", nullable = false)
+  private MenuItem item;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id", nullable = false)
-    private User reviewer;
+  @ManyToOne
+  @JoinColumn(name = "user_id", nullable = false)
+  private User reviewer;
 }

--- a/src/main/java/edu/ucsb/cs156/dining/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/dining/entities/User.java
@@ -3,53 +3,52 @@ package edu.ucsb.cs156.dining.entities;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import edu.ucsb.cs156.dining.statuses.ModerationStatus;
 import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.*;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
-import java.time.LocalDate;
-import java.util.List;
-
-/**
-* This is a JPA entity that represents a user.
-*/
-
+/** This is a JPA entity that represents a user. */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @Entity(name = "users")
 public class User {
- @Id
- @GeneratedValue(strategy = GenerationType.IDENTITY)
- private long id;
- private String email;
- private String googleSub;
- private String pictureUrl;
- private String fullName;
- private String givenName;
- private String familyName;
- private boolean emailVerified;
- private String locale;
- private String hostedDomain;
- private boolean admin;
- private boolean moderator;
- private String alias;
- private String proposedAlias;
- @Enumerated(EnumType.STRING)
- private ModerationStatus status;
- private LocalDate dateApproved;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
 
- @ToString.Exclude
- @JsonIgnore
- @OneToMany(mappedBy="reviewer")
- @Fetch(FetchMode.JOIN)
- private List<Review> reviews;
- 
- public String getAlias() {
-        if (this.alias == null) {
-            this.alias = "Anonymous User"; 
-        }
-        return this.alias;
+  private String email;
+  private String googleSub;
+  private String pictureUrl;
+  private String fullName;
+  private String givenName;
+  private String familyName;
+  private boolean emailVerified;
+  private String locale;
+  private String hostedDomain;
+  private boolean admin;
+  private boolean moderator;
+  private String alias;
+  private String proposedAlias;
+
+  @Enumerated(EnumType.STRING)
+  private ModerationStatus status;
+
+  private LocalDate dateApproved;
+
+  @ToString.Exclude
+  @JsonIgnore
+  @OneToMany(mappedBy = "reviewer")
+  @Fetch(FetchMode.JOIN)
+  private List<Review> reviews;
+
+  public String getAlias() {
+    if (this.alias == null) {
+      this.alias = "Anonymous User";
     }
+    return this.alias;
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/dining/errors/EntityNotFoundException.java
+++ b/src/main/java/edu/ucsb/cs156/dining/errors/EntityNotFoundException.java
@@ -1,18 +1,17 @@
 package edu.ucsb.cs156.dining.errors;
 
 /**
- * This is an error class for a custom RuntimeException in Java that is used to indicate
- * when an entity of a specific type with a given ID is not found.
+ * This is an error class for a custom RuntimeException in Java that is used to indicate when an
+ * entity of a specific type with a given ID is not found.
  */
 public class EntityNotFoundException extends RuntimeException {
   /**
    * Constructor for the exception
-   * 
+   *
    * @param entityType The class of the entity that was not found, e.g. User.class
    * @param id the id that was being searched for
    */
   public EntityNotFoundException(Class<?> entityType, Object id) {
-    super("%s with id %s not found"
-      .formatted(entityType.getSimpleName(), id.toString()));
+    super("%s with id %s not found".formatted(entityType.getSimpleName(), id.toString()));
   }
 }

--- a/src/main/java/edu/ucsb/cs156/dining/interceptors/RoleInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/dining/interceptors/RoleInterceptor.java
@@ -1,61 +1,63 @@
 package edu.ucsb.cs156.dining.interceptors;
 
+import edu.ucsb.cs156.dining.entities.User;
+import edu.ucsb.cs156.dining.repositories.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.HandlerInterceptor;
-
-import edu.ucsb.cs156.dining.repositories.UserRepository;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-
-import java.util.Optional;
-import java.util.Set;
-import java.util.Collection;
-import java.util.stream.Collectors;
-import edu.ucsb.cs156.dining.entities.User;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
 
 @Slf4j
 @Component
 public class RoleInterceptor implements HandlerInterceptor {
 
-    @Autowired
-    UserRepository userRepository;
+  @Autowired UserRepository userRepository;
 
-    @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+  @Override
+  public boolean preHandle(
+      HttpServletRequest request, HttpServletResponse response, Object handler) {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (authentication.getClass() == OAuth2AuthenticationToken.class) {
-            OAuth2User principal = ((OAuth2AuthenticationToken) authentication).getPrincipal();
-            String email = principal.getAttribute("email");
-            Optional<User> optionalUser = userRepository.findByEmail(email);
-            if (optionalUser.isPresent()) {
-                User user = optionalUser.get();
-                Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
-                Set<GrantedAuthority> revisedAuthorities = authorities.stream().filter(
-                        grantedAuth -> !grantedAuth.getAuthority().equals("ROLE_ADMIN")
-                                && !grantedAuth.getAuthority().equals("ROLE_MODERATOR"))
-                        .collect(Collectors.toSet());
-                if (user.getAdmin()) {
-                    revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
-                }
-                if (user.getModerator()) {
-                    revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_MODERATOR"));
-                }
-                Authentication newAuth = new OAuth2AuthenticationToken(principal, revisedAuthorities,
-                        (((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId()));
-                SecurityContextHolder.getContext().setAuthentication(newAuth);
-            }
+    if (authentication.getClass() == OAuth2AuthenticationToken.class) {
+      OAuth2User principal = ((OAuth2AuthenticationToken) authentication).getPrincipal();
+      String email = principal.getAttribute("email");
+      Optional<User> optionalUser = userRepository.findByEmail(email);
+      if (optionalUser.isPresent()) {
+        User user = optionalUser.get();
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Set<GrantedAuthority> revisedAuthorities =
+            authorities.stream()
+                .filter(
+                    grantedAuth ->
+                        !grantedAuth.getAuthority().equals("ROLE_ADMIN")
+                            && !grantedAuth.getAuthority().equals("ROLE_MODERATOR"))
+                .collect(Collectors.toSet());
+        if (user.getAdmin()) {
+          revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
         }
-        return true;
+        if (user.getModerator()) {
+          revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_MODERATOR"));
+        }
+        Authentication newAuth =
+            new OAuth2AuthenticationToken(
+                principal,
+                revisedAuthorities,
+                (((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId()));
+        SecurityContextHolder.getContext().setAuthentication(newAuth);
+      }
     }
+    return true;
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/dining/interceptors/RoleInterceptorConfig.java
+++ b/src/main/java/edu/ucsb/cs156/dining/interceptors/RoleInterceptorConfig.java
@@ -8,12 +8,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Component
 public class RoleInterceptorConfig implements WebMvcConfigurer {
 
-    @Autowired
-    private RoleInterceptor roleInterceptor;
+  @Autowired private RoleInterceptor roleInterceptor;
 
-    @Override
-    public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(roleInterceptor);
-    }
-
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(roleInterceptor);
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/dining/models/CurrentUser.java
+++ b/src/main/java/edu/ucsb/cs156/dining/models/CurrentUser.java
@@ -1,21 +1,15 @@
 package edu.ucsb.cs156.dining.models;
 
-import lombok.Data;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import lombok.Builder;
-import lombok.AccessLevel;
-
-
-import org.springframework.security.core.GrantedAuthority;
 import edu.ucsb.cs156.dining.entities.User;
-
 import java.util.Collection;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
 
-/**
- * This is a model class that represents the current user.
- */
-
+/** This is a model class that represents the current user. */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/edu/ucsb/cs156/dining/models/DiningCommons.java
+++ b/src/main/java/edu/ucsb/cs156/dining/models/DiningCommons.java
@@ -1,13 +1,11 @@
 package edu.ucsb.cs156.dining.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import java.util.Map;
-
-import static java.lang.Double.parseDouble;
 
 @Builder
 @Data
@@ -22,10 +20,10 @@ public class DiningCommons {
   private Double latitude;
   private Double longitude;
 
-
-  //Found this on Baeldung for unpacking nested json properties: https://www.baeldung.com/jackson-nested-values
+  // Found this on Baeldung for unpacking nested json properties:
+  // https://www.baeldung.com/jackson-nested-values
   @JsonProperty("location")
-  private void unpackedNested(Map<String,Object> location){
+  private void unpackedNested(Map<String, Object> location) {
     this.latitude = (Double) location.get("latitude");
     this.longitude = (Double) location.get("longitude");
   }

--- a/src/main/java/edu/ucsb/cs156/dining/models/EditedReview.java
+++ b/src/main/java/edu/ucsb/cs156/dining/models/EditedReview.java
@@ -1,18 +1,17 @@
 package edu.ucsb.cs156.dining.models;
 
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 public class EditedReview {
-    private Long itemStars;
-    private String reviewerComments;
-    private LocalDateTime dateItemServed;
+  private Long itemStars;
+  private String reviewerComments;
+  private LocalDateTime dateItemServed;
 }

--- a/src/main/java/edu/ucsb/cs156/dining/models/Entree.java
+++ b/src/main/java/edu/ucsb/cs156/dining/models/Entree.java
@@ -1,6 +1,5 @@
 package edu.ucsb.cs156.dining.models;
 
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/edu/ucsb/cs156/dining/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/dining/models/SystemInfo.java
@@ -1,17 +1,16 @@
 package edu.ucsb.cs156.dining.models;
 
-import lombok.Data;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import lombok.Builder;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * This is a model class that represents system information.
- * 
- * This class is used to provide information about the system to the frontend.
+ *
+ * <p>This class is used to provide information about the system to the frontend.
  */
-
 @Data
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/edu/ucsb/cs156/dining/repositories/MenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/dining/repositories/MenuItemRepository.java
@@ -1,22 +1,23 @@
 package edu.ucsb.cs156.dining.repositories;
 
 import edu.ucsb.cs156.dining.entities.MenuItem;
+import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
-
 
 @Repository
 public interface MenuItemRepository extends CrudRepository<MenuItem, Long> {
   /**
    * This method returns a MenuItem entity with a given id.
+   *
    * @param diningCommonsCode of menu item
    * @param mealCode of menu item
    * @param name of menu item
    * @param station of menu item
    * @return Optional of Menu item based on the parameters (empty if not found)
    */
-  Optional<MenuItem> findByDiningCommonsCodeAndMealCodeAndNameAndStation(String diningCommonsCode, String mealCode, String name, String station);
+  Optional<MenuItem> findByDiningCommonsCodeAndMealCodeAndNameAndStation(
+      String diningCommonsCode, String mealCode, String name, String station);
+
   boolean existsById(Long id);
 }

--- a/src/main/java/edu/ucsb/cs156/dining/repositories/ReviewRepository.java
+++ b/src/main/java/edu/ucsb/cs156/dining/repositories/ReviewRepository.java
@@ -1,29 +1,22 @@
 package edu.ucsb.cs156.dining.repositories;
 
 import edu.ucsb.cs156.dining.entities.Review;
-
 import edu.ucsb.cs156.dining.entities.User;
 import edu.ucsb.cs156.dining.statuses.ModerationStatus;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
-/**
- * The ReviewRepository is a repository for Review entities
- */
+/** The ReviewRepository is a repository for Review entities */
 @Repository
 public interface ReviewRepository extends CrudRepository<Review, Long> {
 
+  /**
+   * @param user
+   * @return all reviews that have come from a single reviewer, ex say this user has made a few
+   *     reviews over the past year well then this method will return only the reviews that this
+   *     user has sent
+   */
+  Iterable<Review> findByReviewer(User user);
 
-    /**
-     * 
-     * @param user
-     * @return all reviews that have come from a single reviewer, ex say this user has made a few reviews over the past year
-     * well then this method will return only the reviews that this user has sent 
-     */
-
-    Iterable<Review> findByReviewer(User user);
-
-    Iterable<Review> findByStatus(ModerationStatus moderationStatus);
-
+  Iterable<Review> findByStatus(ModerationStatus moderationStatus);
 }

--- a/src/main/java/edu/ucsb/cs156/dining/repositories/UserRepository.java
+++ b/src/main/java/edu/ucsb/cs156/dining/repositories/UserRepository.java
@@ -1,35 +1,30 @@
 package edu.ucsb.cs156.dining.repositories;
 
 import edu.ucsb.cs156.dining.entities.User;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-import java.util.List;
-
-/**
-* The UserRepository is a repository for User entities.
-*/
+/** The UserRepository is a repository for User entities. */
 @Repository
 public interface UserRepository extends CrudRepository<User, Long> {
- /**
-  * This method returns a User entity with a given email.
-  * @param email email address of the user
-  * @return Optional of User (empty if not found)
-  */
- Optional<User> findByEmail(String email);
+  /**
+   * This method returns a User entity with a given email.
+   *
+   * @param email email address of the user
+   * @return Optional of User (empty if not found)
+   */
+  Optional<User> findByEmail(String email);
 
- /**
-  * This method returns a User entity with an alias.
-  * @param alias alias of the user
-  * @return Optional of User (empty if not found)
-  */
- Optional<User> findByAlias(String alias);
+  /**
+   * This method returns a User entity with an alias.
+   *
+   * @param alias alias of the user
+   * @return Optional of User (empty if not found)
+   */
+  Optional<User> findByAlias(String alias);
 
- /**
-  * This method returns a list of users with proposed alias
-    that is not null.
-  */
- List<User> findByProposedAliasNotNull();
-
+  /** This method returns a list of users with proposed alias that is not null. */
+  List<User> findByProposedAliasNotNull();
 }

--- a/src/main/java/edu/ucsb/cs156/dining/services/CurrentUserService.java
+++ b/src/main/java/edu/ucsb/cs156/dining/services/CurrentUserService.java
@@ -2,44 +2,43 @@ package edu.ucsb.cs156.dining.services;
 
 import edu.ucsb.cs156.dining.entities.User;
 import edu.ucsb.cs156.dining.models.CurrentUser;
-
 import java.util.Collection;
-
 import org.springframework.security.core.GrantedAuthority;
 
 /**
  * This is a service that provides information about the current user.
  *
- * It is an abstract class because we have different implementations for testing and production.
- * 
+ * <p>It is an abstract class because we have different implementations for testing and production.
  */
 public abstract class CurrentUserService {
 
   /**
    * This method returns the current user as a User object.
+   *
    * @return the current user
    */
   public abstract User getUser();
 
   /**
    * This method returns the current user as a CurrentUser object
+   *
    * @return the current user
    */
   public abstract CurrentUser getCurrentUser();
 
   /**
    * This method returns the roles of the current user.
+   *
    * @return a collection of roles
    */
   public abstract Collection<? extends GrantedAuthority> getRoles();
 
   /**
    * This method returns whether the current user is logged in.
+   *
    * @return whether the current user is logged in
    */
-  
   public final boolean isLoggedIn() {
     return getUser() != null;
   }
-
 }

--- a/src/main/java/edu/ucsb/cs156/dining/services/CurrentUserServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/dining/services/CurrentUserServiceImpl.java
@@ -3,13 +3,11 @@ package edu.ucsb.cs156.dining.services;
 import edu.ucsb.cs156.dining.entities.User;
 import edu.ucsb.cs156.dining.models.CurrentUser;
 import edu.ucsb.cs156.dining.repositories.UserRepository;
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
@@ -23,48 +21,44 @@ import org.springframework.stereotype.Service;
 
 /**
  * This is a service that provides information about the current user.
- * 
- * This is the version of the service used in production.
+ *
+ * <p>This is the version of the service used in production.
  */
-
 @Slf4j
 @Service("currentUser")
 @Primary
 public class CurrentUserServiceImpl extends CurrentUserService {
-  @Autowired
-  private UserRepository userRepository;
+  @Autowired private UserRepository userRepository;
 
-  @Autowired
-  GrantedAuthoritiesService grantedAuthoritiesService;
+  @Autowired GrantedAuthoritiesService grantedAuthoritiesService;
 
   @Value("${app.admin.emails}")
-  final private List<String> adminEmails = new ArrayList<String>();
+  private final List<String> adminEmails = new ArrayList<String>();
 
   /**
    * This method returns the current user as a User object.
+   *
    * @return the current user
    */
   public CurrentUser getCurrentUser() {
-    CurrentUser cu = CurrentUser.builder()
-      .user(this.getUser())
-      .roles(this.getRoles())
-      .build();
-    log.info("getCurrentUser returns {}",cu);
+    CurrentUser cu = CurrentUser.builder().user(this.getUser()).roles(this.getRoles()).build();
+    log.info("getCurrentUser returns {}", cu);
     return cu;
   }
 
   /**
-   * This method obtains the current user that is logged in with OAuth2, if any.
-   * The parameters are automatically injected by Spring.
-   * 
-   * This method also has a side effect of storing the user in the database if they are not already there.
-   * 
+   * This method obtains the current user that is logged in with OAuth2, if any. The parameters are
+   * automatically injected by Spring.
+   *
+   * <p>This method also has a side effect of storing the user in the database if they are not
+   * already there.
+   *
    * @param securityContext the security context (provided by Spring)
    * @param authentication the authentication token (provided by Spring)
    * @return the User object representing the current user
    */
-  
-  public User getOAuth2AuthenticatedUser(SecurityContext securityContext, Authentication authentication) {
+  public User getOAuth2AuthenticatedUser(
+      SecurityContext securityContext, Authentication authentication) {
     OAuth2User oAuthUser = ((OAuth2AuthenticationToken) authentication).getPrincipal();
     String email = oAuthUser.getAttribute("email");
     String googleSub = oAuthUser.getAttribute("sub");
@@ -76,8 +70,8 @@ public class CurrentUserServiceImpl extends CurrentUserService {
     String locale = oAuthUser.getAttribute("locale");
     String hostedDomain = oAuthUser.getAttribute("hd");
 
-    java.util.Map<java.lang.String,java.lang.Object> attrs = oAuthUser.getAttributes();
-    log.info("attrs={}",attrs);
+    java.util.Map<java.lang.String, java.lang.Object> attrs = oAuthUser.getAttributes();
+    log.info("attrs={}", attrs);
 
     Optional<User> ou = userRepository.findByEmail(email);
     if (ou.isPresent()) {
@@ -89,24 +83,26 @@ public class CurrentUserServiceImpl extends CurrentUserService {
       return u;
     }
 
-    User u = User.builder()
-        .googleSub(googleSub)
-        .email(email)
-        .pictureUrl(pictureUrl)
-        .fullName(fullName)
-        .givenName(givenName)
-        .familyName(familyName)
-        .emailVerified(emailVerified)
-        .locale(locale)
-        .hostedDomain(hostedDomain)
-        .admin(adminEmails.contains(email))
-        .build();
+    User u =
+        User.builder()
+            .googleSub(googleSub)
+            .email(email)
+            .pictureUrl(pictureUrl)
+            .fullName(fullName)
+            .givenName(givenName)
+            .familyName(familyName)
+            .emailVerified(emailVerified)
+            .locale(locale)
+            .hostedDomain(hostedDomain)
+            .admin(adminEmails.contains(email))
+            .build();
     userRepository.save(u);
     return u;
   }
 
   /**
    * This method returns the current user as a User object.
+   *
    * @return the current user
    */
   public User getUser() {
@@ -121,9 +117,10 @@ public class CurrentUserServiceImpl extends CurrentUserService {
 
   /**
    * This method returns the roles of the current user.
+   *
    * @return a collection of roles
    */
   public Collection<? extends GrantedAuthority> getRoles() {
-   return grantedAuthoritiesService.getGrantedAuthorities();
+    return grantedAuthoritiesService.getGrantedAuthorities();
   }
 }

--- a/src/main/java/edu/ucsb/cs156/dining/services/DiningCommonsService.java
+++ b/src/main/java/edu/ucsb/cs156/dining/services/DiningCommonsService.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.dining.models.DiningCommons;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,8 +35,7 @@ public class DiningCommonsService {
   @Value("${app.ucsb.api.consumer_key}")
   private String apiKey;
 
-  public static final String ENDPOINT =
-      "https://api.ucsb.edu/dining/commons/v1/";
+  public static final String ENDPOINT = "https://api.ucsb.edu/dining/commons/v1/";
 
   private final RestTemplate restTemplate;
 

--- a/src/main/java/edu/ucsb/cs156/dining/services/GrantedAuthoritiesService.java
+++ b/src/main/java/edu/ucsb/cs156/dining/services/GrantedAuthoritiesService.java
@@ -1,35 +1,32 @@
 package edu.ucsb.cs156.dining.services;
 
 import java.util.Collection;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
-import lombok.extern.slf4j.Slf4j;
-
 /**
- * The is a service that retrieves and logs the granted authorities for the
- * current user's authentication.
+ * The is a service that retrieves and logs the granted authorities for the current user's
+ * authentication.
  */
 @Slf4j
 @Service("grantedAuthorities")
 public class GrantedAuthoritiesService {
 
-    /**
-     * The function retrieves and logs the granted authorities from the current security context in a
-     * Java application.
-     * 
-     * @return collection of authorities granted to the currently authenticated user.
-     */
-    public Collection<? extends GrantedAuthority> getGrantedAuthorities() {
-        SecurityContext securityContext = SecurityContextHolder.getContext();
-        Authentication authentication = securityContext.getAuthentication();
-        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
-        log.info("authorities={}", authorities);
-        return authorities;
-    }
-
+  /**
+   * The function retrieves and logs the granted authorities from the current security context in a
+   * Java application.
+   *
+   * @return collection of authorities granted to the currently authenticated user.
+   */
+  public Collection<? extends GrantedAuthority> getGrantedAuthorities() {
+    SecurityContext securityContext = SecurityContextHolder.getContext();
+    Authentication authentication = securityContext.getAuthentication();
+    Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+    log.info("authorities={}", authorities);
+    return authorities;
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/dining/services/SystemInfoService.java
+++ b/src/main/java/edu/ucsb/cs156/dining/services/SystemInfoService.java
@@ -2,17 +2,16 @@ package edu.ucsb.cs156.dining.services;
 
 import edu.ucsb.cs156.dining.models.SystemInfo;
 
-
 /**
- * The SystemInfoService is a service that provides global information about 
- * the system and makes it available to the frontend.  For details on what
- * information is provided, see the SystemInfo class.
- * 
+ * The SystemInfoService is a service that provides global information about the system and makes it
+ * available to the frontend. For details on what information is provided, see the SystemInfo class.
+ *
  * @see edu.ucsb.cs156.dining.models.SystemInfo
  */
 public abstract class SystemInfoService {
   /**
    * This method returns the system information.
+   *
    * @see edu.ucsb.cs156.dining.models.SystemInfo
    * @return the system information
    */

--- a/src/main/java/edu/ucsb/cs156/dining/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/dining/services/SystemInfoServiceImpl.java
@@ -1,6 +1,5 @@
 package edu.ucsb.cs156.dining.services;
 
-
 import edu.ucsb.cs156.dining.models.SystemInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,18 +10,14 @@ import org.springframework.stereotype.Service;
 
 /**
  * This is a service for getting information about the system.
- * 
- * This class relies on property values. For hints on testing, see: <a href=
+ *
+ * <p>This class relies on property values. For hints on testing, see: <a href=
  * "https://www.baeldung.com/spring-boot-testing-configurationproperties">https://www.baeldung.com/spring-boot-testing-configurationproperties</a>
- * 
  */
-
 @Slf4j
 @Service("systemInfo")
 @ConfigurationProperties
-@PropertySources(
-  @PropertySource("classpath:git.properties")
-)
+@PropertySources(@PropertySource("classpath:git.properties"))
 public class SystemInfoServiceImpl extends SystemInfoService {
 
   @Value("${spring.h2.console.enabled:false}")
@@ -49,21 +44,22 @@ public class SystemInfoServiceImpl extends SystemInfoService {
 
   /**
    * This method returns the system information.
+   *
    * @see edu.ucsb.cs156.dining.models.SystemInfo
    * @return the system information
    */
   public SystemInfo getSystemInfo() {
-    SystemInfo si = SystemInfo.builder()
-        .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
-        .showSwaggerUILink(this.showSwaggerUILink)
-        .oauthLogin(this.oauthLogin)
-        .sourceRepo(this.sourceRepo)
-        .commitMessage(this.commitMessage)
-        .commitId(this.commitId)
-        .githubUrl(githubUrl(this.sourceRepo, this.commitId))
-        .build();
+    SystemInfo si =
+        SystemInfo.builder()
+            .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
+            .showSwaggerUILink(this.showSwaggerUILink)
+            .oauthLogin(this.oauthLogin)
+            .sourceRepo(this.sourceRepo)
+            .commitMessage(this.commitMessage)
+            .commitId(this.commitId)
+            .githubUrl(githubUrl(this.sourceRepo, this.commitId))
+            .build();
     log.info("getSystemInfo returns {}", si);
     return si;
   }
-
 }

--- a/src/main/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuItemsService.java
+++ b/src/main/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuItemsService.java
@@ -1,13 +1,10 @@
 package edu.ucsb.cs156.dining.services;
 
-import edu.ucsb.cs156.dining.models.Entree;
-
-import java.util.Arrays;
-import java.util.List;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.dining.models.Entree;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,7 +12,6 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -25,47 +21,47 @@ import org.springframework.web.client.RestTemplate;
 @Slf4j
 public class UCSBDiningMenuItemsService {
 
-    @Autowired private ObjectMapper objectMapper;
+  @Autowired private ObjectMapper objectMapper;
 
-    @Value("${app.ucsb.api.consumer_key}")
-    private String apiKey;
+  @Value("${app.ucsb.api.consumer_key}")
+  private String apiKey;
 
-    private RestTemplate restTemplate = new RestTemplate();
+  private RestTemplate restTemplate = new RestTemplate();
 
-    public UCSBDiningMenuItemsService(RestTemplateBuilder restTemplateBuilder) throws Exception {
-        restTemplate = restTemplateBuilder.build();
-    }
+  public UCSBDiningMenuItemsService(RestTemplateBuilder restTemplateBuilder) throws Exception {
+    restTemplate = restTemplateBuilder.build();
+  }
 
-    public static final String ALL_MEAL_ITEMS_AT_A_DINING_COMMON_ENDPOINT =
+  public static final String ALL_MEAL_ITEMS_AT_A_DINING_COMMON_ENDPOINT =
       "https://api.ucsb.edu/dining/menu/v1/{date-time}/{dining-common-code}/{meal-code}";
 
-    /**
+  /**
    * Create a List of Entree from json representation
+   *
    * @param dateTime String of date in iso format
-   * @param diningCommonCode String of dining common 
+   * @param diningCommonCode String of dining common
    * @param mealCode String of meal code
    * @return a list of menu items
    */
+  public List<Entree> get(String dateTime, String diningCommonCode, String mealCode)
+      throws JsonProcessingException {
 
-    public List<Entree> get(String dateTime, String diningCommonCode, String mealCode) throws JsonProcessingException {
-        
-        HttpHeaders headers = new HttpHeaders();
-        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.set("ucsb-api-key", this.apiKey);
+    HttpHeaders headers = new HttpHeaders();
+    headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.set("ucsb-api-key", this.apiKey);
 
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-        String url = ALL_MEAL_ITEMS_AT_A_DINING_COMMON_ENDPOINT;
-        url = url.replace("{date-time}", dateTime);
-        url = url.replace("{dining-common-code}", diningCommonCode);
-        url = url.replace("{meal-code}", mealCode);
+    HttpEntity<String> entity = new HttpEntity<>(headers);
+    String url = ALL_MEAL_ITEMS_AT_A_DINING_COMMON_ENDPOINT;
+    url = url.replace("{date-time}", dateTime);
+    url = url.replace("{dining-common-code}", diningCommonCode);
+    url = url.replace("{meal-code}", mealCode);
 
-        ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
-        String retBody = re.getBody();
+    ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+    String retBody = re.getBody();
 
-        List<Entree> menuItems = objectMapper.readValue(retBody, new TypeReference<List<Entree>>() {});
+    List<Entree> menuItems = objectMapper.readValue(retBody, new TypeReference<List<Entree>>() {});
 
-        return menuItems;
-    }
-
+    return menuItems;
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuService.java
+++ b/src/main/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuService.java
@@ -1,14 +1,9 @@
 package edu.ucsb.cs156.dining.services;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
@@ -25,46 +20,46 @@ import org.springframework.web.client.RestTemplate;
 @Slf4j
 public class UCSBDiningMenuService {
 
-    @Value("${app.ucsb.api.consumer_key}")
-    private String apiKey;
+  @Value("${app.ucsb.api.consumer_key}")
+  private String apiKey;
 
-    private RestTemplate restTemplate = new RestTemplate();
+  private RestTemplate restTemplate = new RestTemplate();
 
-    public UCSBDiningMenuService(RestTemplateBuilder restTemplateBuilder) throws Exception {
-        restTemplate = restTemplateBuilder.build();
-    }
+  public UCSBDiningMenuService(RestTemplateBuilder restTemplateBuilder) throws Exception {
+    restTemplate = restTemplateBuilder.build();
+  }
 
-    public static final String ALL_MEAL_TIMES_AT_A_DINING_COMMON_ENDPOINT =
+  public static final String ALL_MEAL_TIMES_AT_A_DINING_COMMON_ENDPOINT =
       "https://api.ucsb.edu/dining/menu/v1/{date-time}/{dining-common-code}";
 
-    public String getJSON(String dateTime, String diningCommonCode) throws Exception {
+  public String getJSON(String dateTime, String diningCommonCode) throws Exception {
 
-      HttpHeaders headers = new HttpHeaders();
-      headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
-      headers.setContentType(MediaType.APPLICATION_JSON);
-      headers.set("ucsb-api-version", "1.0");
-      headers.set("ucsb-api-key", this.apiKey);
+    HttpHeaders headers = new HttpHeaders();
+    headers.setAccept(Arrays.asList(MediaType.APPLICATION_JSON));
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.set("ucsb-api-version", "1.0");
+    headers.set("ucsb-api-key", this.apiKey);
 
-      HttpEntity<String> entity = new HttpEntity<>("body", headers);
+    HttpEntity<String> entity = new HttpEntity<>("body", headers);
 
-      String url = ALL_MEAL_TIMES_AT_A_DINING_COMMON_ENDPOINT;
-      url.replace("{date-time}", dateTime);
-      url.replace("{dining-common-code}", diningCommonCode);
-        
+    String url = ALL_MEAL_TIMES_AT_A_DINING_COMMON_ENDPOINT;
+    url.replace("{date-time}", dateTime);
+    url.replace("{dining-common-code}", diningCommonCode);
 
-      log.info("url=" + url);
+    log.info("url=" + url);
 
-      String retVal = "";
-      MediaType contentType = null;
-      HttpStatus statusCode = null;
+    String retVal = "";
+    MediaType contentType = null;
+    HttpStatus statusCode = null;
 
-      ResponseEntity<String> re = restTemplate.exchange(url, HttpMethod.GET, entity, String.class, dateTime, diningCommonCode);
-      contentType = re.getHeaders().getContentType();
-      statusCode = (HttpStatus) re.getStatusCode();
-      retVal = re.getBody();
+    ResponseEntity<String> re =
+        restTemplate.exchange(
+            url, HttpMethod.GET, entity, String.class, dateTime, diningCommonCode);
+    contentType = re.getHeaders().getContentType();
+    statusCode = (HttpStatus) re.getStatusCode();
+    retVal = re.getBody();
 
-      log.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
-      return retVal;
-    }
+    log.info("json: {} contentType: {} statusCode: {}", retVal, contentType, statusCode);
+    return retVal;
+  }
 }
-

--- a/src/main/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuService.java
+++ b/src/main/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuService.java
@@ -1,7 +1,5 @@
 package edu.ucsb.cs156.dining.services;
 
-
-
 import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/edu/ucsb/cs156/dining/services/wiremock/WiremockService.java
+++ b/src/main/java/edu/ucsb/cs156/dining/services/wiremock/WiremockService.java
@@ -4,19 +4,20 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 
 /**
  * This is a service for mocking authentication using wiremock
- * 
- * This class relies on property values. For hints on testing, see: <a href="https://www.baeldung.com/spring-boot-testing-configurationproperties">https://www.baeldung.com/spring-boot-testing-configurationproperties</a>
- * 
- * There are two imlementations of the class, depending on the profile in use
+ *
+ * <p>This class relies on property values. For hints on testing, see: <a
+ * href="https://www.baeldung.com/spring-boot-testing-configurationproperties">https://www.baeldung.com/spring-boot-testing-configurationproperties</a>
+ *
+ * <p>There are two imlementations of the class, depending on the profile in use
  */
 public abstract class WiremockService {
   /**
    * This method returns the wiremockServer
+   *
    * @return the wiremockServer
    */
   public abstract WireMockServer getWiremockServer();
-  /**
-   * This method initializes the WireMockServer 
-   */
+
+  /** This method initializes the WireMockServer */
   public abstract void init();
 }

--- a/src/main/java/edu/ucsb/cs156/dining/services/wiremock/WiremockServiceDummy.java
+++ b/src/main/java/edu/ucsb/cs156/dining/services/wiremock/WiremockServiceDummy.java
@@ -1,37 +1,33 @@
 package edu.ucsb.cs156.dining.services.wiremock;
 
-
+import com.github.tomakehurst.wiremock.WireMockServer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
-
 /**
- * This is a dummy service for profiles besides wiremock where we do not want the mocked authentication,
- * but instead real oauth authentication
+ * This is a dummy service for profiles besides wiremock where we do not want the mocked
+ * authentication, but instead real oauth authentication
  */
 @Slf4j
 @Service("wiremockService")
 @Profile("!wiremock")
 @ConfigurationProperties
 public class WiremockServiceDummy extends WiremockService {
-  
-    /**
-     * Dummy call for getWiremockServer()
-     * @return null
-     */
-    public WireMockServer getWiremockServer() {
-      return null;
-    }
 
-    /**
-     * Dummy call to init
-     */
-    public void init() {
-      log.info("WiremockServiceDummy.init() called");
-      log.info("WiremockServiceDummy.init() completed");
-    }
+  /**
+   * Dummy call for getWiremockServer()
+   *
+   * @return null
+   */
+  public WireMockServer getWiremockServer() {
+    return null;
+  }
 
+  /** Dummy call to init */
+  public void init() {
+    log.info("WiremockServiceDummy.init() called");
+    log.info("WiremockServiceDummy.init() completed");
+  }
 }

--- a/src/main/java/edu/ucsb/cs156/dining/services/wiremock/WiremockServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/dining/services/wiremock/WiremockServiceImpl.java
@@ -1,14 +1,5 @@
 package edu.ucsb.cs156.dining.services.wiremock;
 
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Service;
-
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
-import com.github.tomakehurst.wiremock.junit.Stubbing;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
@@ -18,12 +9,18 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.junit.Stubbing;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
 /**
  * This is a service for mocking authentication using wiremock
- * 
- * This class relies on property values. For hints on testing, see: <a href=
+ *
+ * <p>This class relies on property values. For hints on testing, see: <a href=
  * "https://www.baeldung.com/spring-boot-testing-configurationproperties">https://www.baeldung.com/spring-boot-testing-configurationproperties</a>
- * 
  */
 @Slf4j
 @Service("wiremockService")
@@ -35,7 +32,7 @@ public class WiremockServiceImpl extends WiremockService {
 
   /**
    * This method returns the wiremockServer
-   * 
+   *
    * @return the wiremockServer
    */
   public WireMockServer getWiremockServer() {
@@ -44,33 +41,40 @@ public class WiremockServiceImpl extends WiremockService {
 
   /**
    * This method sets up the necessary mocks for authentication
-   * 
+   *
    * @param s in an instance of a WireMockServer or WireMockExtension
    */
   public static void setupOauthMocks(Stubbing s, boolean isAdmin) {
 
-    s.stubFor(get(urlPathMatching("/oauth/authorize.*"))
-        .willReturn(aResponse()
-            .withStatus(200)
-            .withHeader("Content-Type", "text/html")
-            .withBodyFile("login.html")));
+    s.stubFor(
+        get(urlPathMatching("/oauth/authorize.*"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "text/html")
+                    .withBodyFile("login.html")));
 
-    s.stubFor(post(urlPathEqualTo("/login"))
-        .willReturn(temporaryRedirect(
-            "{{formData request.body 'form' urlDecode=true}}{{{form.redirectUri}}}?code={{{randomValue length=30 type='ALPHANUMERIC'}}}&state={{{form.state}}}")));
+    s.stubFor(
+        post(urlPathEqualTo("/login"))
+            .willReturn(
+                temporaryRedirect(
+                    "{{formData request.body 'form' urlDecode=true}}{{{form.redirectUri}}}?code={{{randomValue length=30 type='ALPHANUMERIC'}}}&state={{{form.state}}}")));
 
-    s.stubFor(post(urlPathEqualTo("/oauth/token"))
-        .willReturn(
-            okJson(
-                "{\"access_token\":\"{{randomValue length=20 type='ALPHANUMERIC'}}\",\"token_type\": \"Bearer\",\"expires_in\":\"3600\",\"scope\":\"https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email openid\"}")));
+    s.stubFor(
+        post(urlPathEqualTo("/oauth/token"))
+            .willReturn(
+                okJson(
+                    "{\"access_token\":\"{{randomValue length=20 type='ALPHANUMERIC'}}\",\"token_type\": \"Bearer\",\"expires_in\":\"3600\",\"scope\":\"https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email openid\"}")));
 
     if (isAdmin) {
-      s.stubFor(get(urlPathMatching("/userinfo"))
-          .willReturn(aResponse()
-              .withStatus(200)
-              .withHeader("Content-Type", "application/json")
-              .withBody(
-                  """
+      s.stubFor(
+          get(urlPathMatching("/userinfo"))
+              .willReturn(
+                  aResponse()
+                      .withStatus(200)
+                      .withHeader("Content-Type", "application/json")
+                      .withBody(
+                          """
                       {
                         "sub": "107126842018026740288",
                         "name": "Admin GaucSho",
@@ -84,12 +88,14 @@ public class WiremockServiceImpl extends WiremockService {
                       }
                       """)));
     } else {
-      s.stubFor(get(urlPathMatching("/userinfo"))
-          .willReturn(aResponse()
-              .withStatus(200)
-              .withHeader("Content-Type", "application/json")
-              .withBody(
-                  """
+      s.stubFor(
+          get(urlPathMatching("/userinfo"))
+              .willReturn(
+                  aResponse()
+                      .withStatus(200)
+                      .withHeader("Content-Type", "application/json")
+                      .withBody(
+                          """
                       {
                         "sub": "107126842018026740288",
                         "name": "Chris Gaucho",
@@ -103,17 +109,13 @@ public class WiremockServiceImpl extends WiremockService {
                       }
                       """)));
     }
-
   }
 
-  /**
-   * This method initializes the WireMockServer
-   */
+  /** This method initializes the WireMockServer */
   public void init() {
     log.info("WiremockServiceImpl.init() called");
 
-    WireMockServer wireMockServer = new WireMockServer(options()
-        .port(8090).globalTemplating(true));
+    WireMockServer wireMockServer = new WireMockServer(options().port(8090).globalTemplating(true));
     setupOauthMocks(wireMockServer, true);
 
     wireMockServer.start();

--- a/src/main/java/edu/ucsb/cs156/dining/statuses/ModerationStatus.java
+++ b/src/main/java/edu/ucsb/cs156/dining/statuses/ModerationStatus.java
@@ -1,5 +1,7 @@
 package edu.ucsb.cs156.dining.statuses;
 
 public enum ModerationStatus {
-    APPROVED, AWAITING_REVIEW, REJECTED;
+  APPROVED,
+  AWAITING_REVIEW,
+  REJECTED;
 }

--- a/src/test/java/edu/ucsb/cs156/dining/ControllerTestCase.java
+++ b/src/test/java/edu/ucsb/cs156/dining/ControllerTestCase.java
@@ -2,41 +2,34 @@ package edu.ucsb.cs156.dining;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import edu.ucsb.cs156.dining.services.CurrentUserService;
+import edu.ucsb.cs156.dining.services.GrantedAuthoritiesService;
+import edu.ucsb.cs156.dining.services.wiremock.WiremockService;
+import edu.ucsb.cs156.dining.testconfig.TestConfig;
+import java.io.UnsupportedEncodingException;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-
-import edu.ucsb.cs156.dining.services.CurrentUserService;
-import edu.ucsb.cs156.dining.services.GrantedAuthoritiesService;
-import edu.ucsb.cs156.dining.services.wiremock.WiremockService;
-import edu.ucsb.cs156.dining.testconfig.TestConfig;
 import org.springframework.test.web.servlet.MvcResult;
-
-import java.io.UnsupportedEncodingException;
-import java.util.Map;
 
 @ActiveProfiles("test")
 @Import(TestConfig.class)
 public abstract class ControllerTestCase {
-  @Autowired
-  public CurrentUserService currentUserService;
+  @Autowired public CurrentUserService currentUserService;
 
-  @Autowired
-  public GrantedAuthoritiesService grantedAuthoritiesService;
+  @Autowired public GrantedAuthoritiesService grantedAuthoritiesService;
 
-  @Autowired
-  public MockMvc mockMvc;
+  @Autowired public MockMvc mockMvc;
 
-  @Autowired
-  public ObjectMapper mapper;
+  @Autowired public ObjectMapper mapper;
 
-  @MockBean
-  WiremockService mockWiremockService;
+  @MockBean WiremockService mockWiremockService;
 
-  protected Map<String, Object> responseToJson(MvcResult result) throws UnsupportedEncodingException, JsonProcessingException {
+  protected Map<String, Object> responseToJson(MvcResult result)
+      throws UnsupportedEncodingException, JsonProcessingException {
     String responseString = result.getResponse().getContentAsString();
     return mapper.readValue(responseString, Map.class);
   }

--- a/src/test/java/edu/ucsb/cs156/dining/WebTestCase.java
+++ b/src/test/java/edu/ucsb/cs156/dining/WebTestCase.java
@@ -1,7 +1,8 @@
 package edu.ucsb.cs156.dining;
 
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
 import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserContext;
 import com.microsoft.playwright.BrowserType;
@@ -15,60 +16,58 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-
 @ActiveProfiles("integration")
 public abstract class WebTestCase {
-    @LocalServerPort
-    private int port;
+  @LocalServerPort private int port;
 
-    @Value("${app.playwright.headless:true}")
-    private boolean runHeadless;
+  @Value("${app.playwright.headless:true}")
+  private boolean runHeadless;
 
-    private static WireMockServer wireMockServer;
+  private static WireMockServer wireMockServer;
 
-    protected Browser browser;
-    protected Page page;
+  protected Browser browser;
+  protected Page page;
 
-    @BeforeAll
-    public static void setupWireMock() {
-        wireMockServer = new WireMockServer(options()
-                .port(8090)
-                .globalTemplating(true));
+  @BeforeAll
+  public static void setupWireMock() {
+    wireMockServer = new WireMockServer(options().port(8090).globalTemplating(true));
 
-        WiremockServiceImpl.setupOauthMocks(wireMockServer, false);
+    WiremockServiceImpl.setupOauthMocks(wireMockServer, false);
 
-        wireMockServer.start();
+    wireMockServer.start();
+  }
+
+  @AfterAll
+  public static void teardownWiremock() {
+    wireMockServer.stop();
+  }
+
+  @AfterEach
+  public void teardown() {
+    browser.close();
+  }
+
+  public void setupUser(boolean isAdmin) {
+    WiremockServiceImpl.setupOauthMocks(wireMockServer, isAdmin);
+
+    browser =
+        Playwright.create()
+            .chromium()
+            .launch(new BrowserType.LaunchOptions().setHeadless(runHeadless));
+
+    BrowserContext context = browser.newContext();
+    page = context.newPage();
+
+    String url = String.format("http://localhost:%d/oauth2/authorization/my-oauth-provider", port);
+    page.navigate(url);
+
+    if (isAdmin) {
+      page.locator("#username").fill("admingaucho@ucsb.edu");
+    } else {
+      page.locator("#username").fill("cgaucho@ucsb.edu");
     }
 
-    @AfterAll
-    public static void teardownWiremock() {
-        wireMockServer.stop();
-    }
-
-    @AfterEach
-    public void teardown() {
-        browser.close();
-    }
-
-    public void setupUser(boolean isAdmin) {
-        WiremockServiceImpl.setupOauthMocks(wireMockServer, isAdmin);
-
-        browser = Playwright.create().chromium().launch(new BrowserType.LaunchOptions().setHeadless(runHeadless));
-
-        BrowserContext context = browser.newContext();
-        page = context.newPage();
-
-        String url = String.format("http://localhost:%d/oauth2/authorization/my-oauth-provider", port);
-        page.navigate(url);
-
-        if (isAdmin) {
-            page.locator("#username").fill("admingaucho@ucsb.edu");
-        } else {
-            page.locator("#username").fill("cgaucho@ucsb.edu");
-        }
-
-        page.locator("#password").fill("password");
-        page.locator("#submit").click();
-    }
+    page.locator("#password").fill("password");
+    page.locator("#submit").click();
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ApiControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ApiControllerTests.java
@@ -1,61 +1,56 @@
 package edu.ucsb.cs156.dining.controllers;
 
-import edu.ucsb.cs156.dining.testconfig.TestConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 import edu.ucsb.cs156.dining.ControllerTestCase;
 import edu.ucsb.cs156.dining.repositories.UserRepository;
-
+import edu.ucsb.cs156.dining.testconfig.TestConfig;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 @WebMvcTest(controllers = DummyController.class)
 @Import(TestConfig.class)
 public class ApiControllerTests extends ControllerTestCase {
 
-    @MockBean
-    UserRepository userRepository;
+  @MockBean UserRepository userRepository;
 
-    @Test
-    public void generic_message_test() {
-        ApiController apiController = new DummyController();
-        Object result = apiController.genericMessage("Hello World");
-        Object expected = Map.of("message", "Hello World");
-        assertEquals(expected,result);
-    }
+  @Test
+  public void generic_message_test() {
+    ApiController apiController = new DummyController();
+    Object result = apiController.genericMessage("Hello World");
+    Object expected = Map.of("message", "Hello World");
+    assertEquals(expected, result);
+  }
 
-    @Test
-    public void test_that_dummy_controller_returns_String1_when_1_is_passed() throws Exception {
+  @Test
+  public void test_that_dummy_controller_returns_String1_when_1_is_passed() throws Exception {
 
-        // act
-        MvcResult response = mockMvc.perform(get("/dummycontroller?id=1"))
-                .andExpect(status().isOk()).andReturn();
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/dummycontroller?id=1")).andExpect(status().isOk()).andReturn();
 
-        // assert
+    // assert
 
-        assertEquals("String1", response.getResponse().getContentAsString());
-    }
+    assertEquals("String1", response.getResponse().getContentAsString());
+  }
 
-    @Test
-    public void test_that_dummy_controller_returns_Exception_when_1_is_not_passed() throws Exception {
+  @Test
+  public void test_that_dummy_controller_returns_Exception_when_1_is_not_passed() throws Exception {
 
-        // act
-        MvcResult response = mockMvc.perform(get("/dummycontroller?id=7"))
-                .andExpect(status().isNotFound()).andReturn();
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/dummycontroller?id=7")).andExpect(status().isNotFound()).andReturn();
 
-        // assert
+    // assert
 
-        Map<String, Object> json = responseToJson(response);
-        assertEquals("EntityNotFoundException", json.get("type"));
-        assertEquals("String with id 7 not found", json.get("message"));
-    }
-
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("String with id 7 not found", json.get("message"));
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/CSRFControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/CSRFControllerTests.java
@@ -1,47 +1,34 @@
 package edu.ucsb.cs156.dining.controllers;
 
-import edu.ucsb.cs156.dining.ControllerTestCase;
-import edu.ucsb.cs156.dining.repositories.UserRepository;
-import edu.ucsb.cs156.dining.testconfig.TestConfig;
-
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.context.WebApplicationContext;
-
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import org.aspectj.lang.annotation.Before;
+import edu.ucsb.cs156.dining.ControllerTestCase;
+import edu.ucsb.cs156.dining.repositories.UserRepository;
+import edu.ucsb.cs156.dining.testconfig.TestConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MvcResult;
 
 @ActiveProfiles("development")
 @WebMvcTest(controllers = CSRFController.class)
 @Import(TestConfig.class)
 public class CSRFControllerTests extends ControllerTestCase {
 
-  @MockBean
-  UserRepository userRepository;
+  @MockBean UserRepository userRepository;
 
   @Test
   public void csrf_returns_ok() throws Exception {
-    MvcResult response = mockMvc.perform(get("/csrf"))
-              .andExpect(status().isOk())
-              .andReturn();
+    MvcResult response = mockMvc.perform(get("/csrf")).andExpect(status().isOk()).andReturn();
 
     String responseString = response.getResponse().getContentAsString();
     assertTrue(responseString.contains("parameterName"));
     assertTrue(responseString.contains("_csrf"));
     assertTrue(responseString.contains("headerName"));
     assertTrue(responseString.contains("X-XSRF-TOKEN"));
-
   }
-
 }

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/DiningCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/DiningCommonsControllerTests.java
@@ -1,36 +1,26 @@
 package edu.ucsb.cs156.dining.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.dining.ControllerTestCase;
 import edu.ucsb.cs156.dining.models.DiningCommons;
-import edu.ucsb.cs156.dining.entities.User;
-import edu.ucsb.cs156.dining.repositories.UserRepository;
 import edu.ucsb.cs156.dining.services.DiningCommonsService;
 import edu.ucsb.cs156.dining.testconfig.TestConfig;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.core.type.TypeReference;
-import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @WebMvcTest(controllers = DiningCommonsController.class)
@@ -86,5 +76,4 @@ public class DiningCommonsControllerTests extends ControllerTestCase {
             response.getResponse().getContentAsString(),
             new TypeReference<List<DiningCommons>>() {}));
   }
-  
 }

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/DummyController.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/DummyController.java
@@ -1,26 +1,21 @@
 package edu.ucsb.cs156.dining.controllers;
 
+import edu.ucsb.cs156.dining.errors.EntityNotFoundException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import edu.ucsb.cs156.dining.errors.EntityNotFoundException;
-
-
-/**
- * This class is used to test ApiController and EntityNotFoundException
- */
-
+/** This class is used to test ApiController and EntityNotFoundException */
 @RequestMapping("/dummycontroller")
 @RestController
 public class DummyController extends ApiController {
 
-    @GetMapping("")
-    public String getById(@RequestParam Long id) throws EntityNotFoundException {
-        if (id == 1) {
-            return "String1";
-        }
-        throw new EntityNotFoundException(String.class, id);
+  @GetMapping("")
+  public String getById(@RequestParam Long id) throws EntityNotFoundException {
+    if (id == 1) {
+      return "String1";
     }
+    throw new EntityNotFoundException(String.class, id);
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
@@ -1,1096 +1,1181 @@
 package edu.ucsb.cs156.dining.controllers;
 
-import edu.ucsb.cs156.dining.errors.EntityNotFoundException;
-import edu.ucsb.cs156.dining.models.EditedReview;
-import edu.ucsb.cs156.dining.repositories.UserRepository;
-import edu.ucsb.cs156.dining.services.CurrentUserService;
-import edu.ucsb.cs156.dining.statuses.ModerationStatus;
-import edu.ucsb.cs156.dining.testconfig.MockCurrentUserServiceImpl;
-import edu.ucsb.cs156.dining.testconfig.TestConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.dining.ControllerTestCase;
 import edu.ucsb.cs156.dining.entities.MenuItem;
 import edu.ucsb.cs156.dining.entities.Review;
 import edu.ucsb.cs156.dining.entities.User;
-import edu.ucsb.cs156.dining.models.CurrentUser;
+import edu.ucsb.cs156.dining.errors.EntityNotFoundException;
+import edu.ucsb.cs156.dining.models.EditedReview;
 import edu.ucsb.cs156.dining.repositories.MenuItemRepository;
 import edu.ucsb.cs156.dining.repositories.ReviewRepository;
-
-import java.time.Duration;
-import java.time.Instant;
+import edu.ucsb.cs156.dining.repositories.UserRepository;
+import edu.ucsb.cs156.dining.services.CurrentUserService;
+import edu.ucsb.cs156.dining.statuses.ModerationStatus;
+import edu.ucsb.cs156.dining.testconfig.TestConfig;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
-
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Answers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.cglib.core.Local;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.auditing.DateTimeProvider;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.web.server.ResponseStatusException;
-
-import com.fasterxml.jackson.databind.JsonNode;
-
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.http.Request;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 
 @WebMvcTest(controllers = ReviewController.class)
 @Import(TestConfig.class)
 public class ReviewControllerTests extends ControllerTestCase {
 
-    @MockBean
-    ReviewRepository reviewRepository;
-
-    @Autowired
-    private ObjectMapper mapper;
-
-    @MockBean
-    UserRepository userRepository;
-
-    @MockBean
-    private MenuItemRepository menuItemRepository;
-
-    @Autowired
-    private CurrentUserService currentUserService;
-
-
-    @BeforeEach
-    void setup() {
-        // Assume an item exists with ID 1
-        when(menuItemRepository.existsById(1L)).thenReturn(true);
-        when(menuItemRepository.findById(1L)).thenReturn(Optional.of(MenuItem.builder().id(1L).build()));
-        when(menuItemRepository.existsById(5L)).thenReturn(false);
-        when(menuItemRepository.existsById(313L)).thenReturn(true);
-        // Assume no item exists with ID 999
-        when(menuItemRepository.existsById(999L)).thenReturn(false);
-    }
-
-    // Authorization tests for /api/request
-
-    @Test
-    public void logged_out_users_cannot_get_all() throws Exception {
-        mockMvc.perform(get("/api/reviews/all"))
-                .andExpect(status().is(403)); // logged out users can't get all
-    }
-
-    @WithMockUser(roles = {"ADMIN"})
-    @Test
-    public void logged_in_admin_can_get_all() throws Exception {
-        mockMvc.perform(get("/api/reviews/all"))
-                .andExpect(status().is(200));
-    }
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void logged_in_user_cant_get_all() throws Exception {
-        mockMvc.perform(get("/api/reviews/all"))
-                .andExpect(status().is(403));
-    }
-
-    @Test
-    public void logged_out_users_cannot_post() throws Exception {
-        mockMvc.perform(post("/api/reviews/post"))
-                .andExpect(status().is(403));
-    }
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void a_user_can_post_a_new_review() throws Exception {
-
-        // Arrange
-        LocalDateTime now = LocalDateTime.now();
-
-        User user = currentUserService.getUser();
-        MenuItem menuItem = MenuItem.builder().id(1L).build();
-
-        Review review = Review.builder()
-                .itemsStars(1l)
-                .reviewerComments("Worst flavor ever.")
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
-                .reviewer(user)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem)
-                .build();
-
-        Review reviewReturn = Review.builder()
-                .dateCreated(now)
-                .dateEdited(now)
-                .itemsStars(1l)
-                .reviewerComments("Worst flavor ever.")
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
-                .reviewer(user)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem)
-                .id(0L)
-                .build();
-        when(reviewRepository.save(eq(review))).thenReturn(reviewReturn);
-
-        // Act
-        MvcResult response = mockMvc.perform(
-                        post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
-                                .with(csrf()))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        String jsonReview = mapper.writeValueAsString(reviewReturn);
-
-        // Assert
-        verify(reviewRepository).save(any(Review.class));
-        String responseJson = response.getResponse().getContentAsString();
-        
-        assertEquals(responseJson, jsonReview);
-    }
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void test_rating_below_1_throws_exception() throws Exception {
-        mockMvc.perform(
-                        post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=0&dateItemServed=2021-12-12T08:08:08")
-                                .with(csrf()))
-                .andDo(print()) // This helps you see the full response for debugging
-                .andExpect(status().isBadRequest());
-    }
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void test_rating_above_5_throws_exception() throws Exception {
-        mockMvc.perform(
-                        post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=6&dateItemServed=2021-12-12T08:08:08")
-                                .with(csrf()))
-                .andDo(print()) // This helps you see the full response for debugging
-                .andExpect(status().isBadRequest());
-    }
-
-    // Test valid input at boundaries
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void postReview_ShouldAcceptRatingAtBoundaries() throws Exception {
-        // Lower boundary test
-        mockMvc.perform(
-                        post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
-                                .with(csrf()))
-                .andExpect(status().isOk());
-        // Lower boundary test
-        mockMvc.perform(
-                        post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=5&dateItemServed=2021-12-12T08:08:08")
-                                .with(csrf()))
-                .andExpect(status().isOk());
-    }
-
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void test_emptyString_on_creating_new_review() throws Exception {
-
-        // Arrange
-        LocalDateTime now = LocalDateTime.now();
-
-        User user = currentUserService.getUser();
-        MenuItem menuItem = MenuItem.builder().id(1L).build();
-
-        Review review = Review.builder()
-                .itemsStars(1l)
-                .reviewerComments(null)
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
-                .reviewer(user)
-                .status(ModerationStatus.APPROVED)
-                .item(menuItem)
-                .build();
-
-        Review reviewReturn = Review.builder()
-                .dateCreated(now)
-                .dateEdited(now)
-                .itemsStars(1l)
-                .reviewerComments(null)
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
-                .reviewer(user)
-                .status(ModerationStatus.APPROVED)
-                .item(menuItem)
-                .id(0L)
-                .build();
-        when(reviewRepository.save(eq(review))).thenReturn(reviewReturn);
-
-        // Act
-        MvcResult response = mockMvc.perform(
-                        post("/api/reviews/post?itemId=1&reviewerComments=&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
-                                .with(csrf()))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        String jsonReview = mapper.writeValueAsString(reviewReturn);
-
-        // Assert
-        verify(reviewRepository).save(any(Review.class));
-        String responseJson = response.getResponse().getContentAsString();
-
-        assertEquals(jsonReview, responseJson);
-    }
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void test_no_string_on_creating_new_review() throws Exception {
-
-        // Arrange
-        LocalDateTime now = LocalDateTime.now();
-
-        User user = currentUserService.getUser();
-        MenuItem menuItem = MenuItem.builder().id(1L).build();
-
-        Review review = Review.builder()
-                .itemsStars(1l)
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
-                .reviewer(user)
-                .status(ModerationStatus.APPROVED)
-                .item(menuItem)
-                .build();
-
-        Review reviewReturn = Review.builder()
-                .dateCreated(now)
-                .dateEdited(now)
-                .itemsStars(1l)
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
-                .reviewer(user)
-                .status(ModerationStatus.APPROVED)
-                .item(menuItem)
-                .id(0L)
-                .build();
-        when(reviewRepository.save(eq(review))).thenReturn(reviewReturn);
-
-        // Act
-        MvcResult response = mockMvc.perform(
-                        post("/api/reviews/post?itemId=1&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
-                                .with(csrf()))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        // Assert
-        verify(reviewRepository).save(any(Review.class));
-        String responseJson = response.getResponse().getContentAsString();
-        String reviewJson = mapper.writeValueAsString(reviewReturn);
-        assertEquals(responseJson, reviewJson);
-
-    }
-
-    @WithMockUser(roles = {"ADMIN"})
-    @Test
-    public void a_logged_in_admin_can_get_all() throws Exception {
-        // Arrange
-
-        LocalDateTime now = LocalDateTime.now();
-
-        User user1 = currentUserService.getUser();
-        User user2 = User.builder().id(2L).build();
-        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
-        MenuItem menuItem2 = MenuItem.builder().id(313L).build();
-
-        Review review1 = Review.builder()
-                .dateCreated(now)
-                .dateEdited(now)
-                .itemsStars(3l)
-                .reviewerComments("Im tired of this same chicken")
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
-                .reviewer(user1)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(0L)
-                .build();
-
-        Review review2 = Review.builder()
-                .dateCreated(now.plusDays(4))
-                .dateEdited(now.plusDays(5))
-                .itemsStars(5l)
-                .reviewerComments("MMMMM I LOVE CHICKEN")
-                .dateItemServed(LocalDateTime.of(2022, 7, 1, 8, 8, 8))
-                .reviewer(user2)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem2)
-                .id(0L)
-                .build();
-
-        Review review3 = Review.builder()
-                .dateCreated(now)
-                .dateEdited(now)
-                .itemsStars(6l)
-                .reviewerComments("Im tired of this same chicken")
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
-                .reviewer(user1)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem2)
-                .id(0L)
-                .build();
-
-        ArrayList<Review> reviews = new ArrayList<>();
-        reviews.addAll(Arrays.asList(review1, review2, review3));
-
-        when(reviewRepository.findAll()).thenReturn(reviews);
-        // Act
-        MvcResult response = mockMvc.perform(get("/api/reviews/all"))
-                .andExpect(status().is(200)).andReturn();
-
-        // assert
-        verify(reviewRepository, times(1)).findAll();
-        String expectedJson = mapper.writeValueAsString(reviews);
-        String responseString = response.getResponse().getContentAsString();
-        assertEquals(expectedJson, responseString);
-    }
-
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void a_logged_in_user_can_get_own_reviews_list() throws Exception {
-        // Arrange
-        User user1 = currentUserService.getUser();
-        User user2 = User.builder().id(2L).build();
-
-        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
-        MenuItem menuItem2 = MenuItem.builder().id(313L).build();
-
-        Review review1 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user1)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-        Review review2 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 4, 28, 1, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 6, 47))
-                .dateItemServed(LocalDateTime.of(2022, 2, 6, 8, 8))
-                .reviewer(user2)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(2L)
-                .build();
-
-        Review review3 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 2, 17, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 12, 15, 04, 26))
-                .dateItemServed(LocalDateTime.of(2023, 1, 7, 3, 8))
-                .reviewer(user2)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem2)
-                .id(3L)
-                .build();
-
-        ArrayList<Review> reviews = new ArrayList<>();
-        ArrayList<Review> valid_reviews = new ArrayList<>();
-        valid_reviews.addAll(Arrays.asList(review1));
-        reviews.addAll(Arrays.asList(review1, review2, review3));
-        when(reviewRepository.findByReviewer(eq(user1))).thenReturn(valid_reviews);
-
-        // Act
-        MvcResult response = mockMvc.perform(
-                        get("/api/reviews/userReviews")
-                                .with(csrf()))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        // assert
-        verify(reviewRepository, times(1)).findByReviewer(eq(user1));
-        String expectedJson = mapper.writeValueAsString(valid_reviews);
-        String responseString = response.getResponse().getContentAsString();
-        assertEquals(expectedJson, responseString);
-
-    }
-
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void testItemIdIsInvalid_NotFound() throws Exception {
-
-        // Act: Perform the request and expect the review creation to fail due to non-existing itemId
-        mockMvc.perform(post("/api/reviews/post")
-                        .param("itemId", "5")  // This itemId does not exist
-                        .param("reviewerComments", "")
-                        .param("itemsStars", "1")
-                        .param("dateItemServed", "2021-12-12T08:08:08")
-                        .with(csrf()))
-                .andExpect(status().isNotFound())
-                .andExpect(result -> assertTrue(result.getResolvedException() instanceof EntityNotFoundException))
-                .andExpect(result -> assertEquals("MenuItem with id 5 not found", result.getResolvedException().getMessage()));
-
-        // Assert: Ensure no reviews are saved due to invalid itemId
-        verify(reviewRepository, times(0)).save(any(Review.class));
-    }
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void wrong_user_cannot_edit() throws Exception{
-        User user2 = User.builder().id(2L).build();
-
-        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
-
-        Review review1 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user2)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-        EditedReview reviewEdit = EditedReview.builder()
-                .reviewerComments("test")
-                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
-                .itemStars(2L)
-                .build();
-
-        String requestBody = mapper.writeValueAsString(reviewEdit);
-
-
-        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
-
-        MvcResult response = mockMvc.perform(put("/api/reviews/reviewer")
-                .param("id", "1")
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding("utf-8")
-                .content(requestBody)
-                .with(csrf())).andExpect(status().isForbidden()).andReturn();
-    }
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void cannot_set_stars_over_boundaries() throws Exception{
-        User user1 = currentUserService.getUser();
-
-        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
-
-        Review review1 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user1)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-        EditedReview reviewTooLow = EditedReview.builder()
-                .reviewerComments("test")
-                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
-                .itemStars(0L)
-                .build();
-
-        EditedReview reviewTooHigh = EditedReview.builder()
-                .reviewerComments("test")
-                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
-                .itemStars(6L)
-                .build();
-
-        String requestBodyTooLow = mapper.writeValueAsString(reviewTooLow);
-        String requestBodyTooHigh = mapper.writeValueAsString(reviewTooHigh);
-
-
-        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
-
-        mockMvc.perform(put("/api/reviews/reviewer")
+  @MockBean ReviewRepository reviewRepository;
+
+  @Autowired private ObjectMapper mapper;
+
+  @MockBean UserRepository userRepository;
+
+  @MockBean private MenuItemRepository menuItemRepository;
+
+  @Autowired private CurrentUserService currentUserService;
+
+  @BeforeEach
+  void setup() {
+    // Assume an item exists with ID 1
+    when(menuItemRepository.existsById(1L)).thenReturn(true);
+    when(menuItemRepository.findById(1L))
+        .thenReturn(Optional.of(MenuItem.builder().id(1L).build()));
+    when(menuItemRepository.existsById(5L)).thenReturn(false);
+    when(menuItemRepository.existsById(313L)).thenReturn(true);
+    // Assume no item exists with ID 999
+    when(menuItemRepository.existsById(999L)).thenReturn(false);
+  }
+
+  // Authorization tests for /api/request
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc
+        .perform(get("/api/reviews/all"))
+        .andExpect(status().is(403)); // logged out users can't get all
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void logged_in_admin_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/reviews/all")).andExpect(status().is(200));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_cant_get_all() throws Exception {
+    mockMvc.perform(get("/api/reviews/all")).andExpect(status().is(403));
+  }
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc.perform(post("/api/reviews/post")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void a_user_can_post_a_new_review() throws Exception {
+
+    // Arrange
+    LocalDateTime now = LocalDateTime.now();
+
+    User user = currentUserService.getUser();
+    MenuItem menuItem = MenuItem.builder().id(1L).build();
+
+    Review review =
+        Review.builder()
+            .itemsStars(1l)
+            .reviewerComments("Worst flavor ever.")
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
+            .reviewer(user)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem)
+            .build();
+
+    Review reviewReturn =
+        Review.builder()
+            .dateCreated(now)
+            .dateEdited(now)
+            .itemsStars(1l)
+            .reviewerComments("Worst flavor ever.")
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
+            .reviewer(user)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem)
+            .id(0L)
+            .build();
+    when(reviewRepository.save(eq(review))).thenReturn(reviewReturn);
+
+    // Act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String jsonReview = mapper.writeValueAsString(reviewReturn);
+
+    // Assert
+    verify(reviewRepository).save(any(Review.class));
+    String responseJson = response.getResponse().getContentAsString();
+
+    assertEquals(responseJson, jsonReview);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_rating_below_1_throws_exception() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=0&dateItemServed=2021-12-12T08:08:08")
+                .with(csrf()))
+        .andDo(print()) // This helps you see the full response for debugging
+        .andExpect(status().isBadRequest());
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_rating_above_5_throws_exception() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=6&dateItemServed=2021-12-12T08:08:08")
+                .with(csrf()))
+        .andDo(print()) // This helps you see the full response for debugging
+        .andExpect(status().isBadRequest());
+  }
+
+  // Test valid input at boundaries
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void postReview_ShouldAcceptRatingAtBoundaries() throws Exception {
+    // Lower boundary test
+    mockMvc
+        .perform(
+            post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
+                .with(csrf()))
+        .andExpect(status().isOk());
+    // Lower boundary test
+    mockMvc
+        .perform(
+            post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=5&dateItemServed=2021-12-12T08:08:08")
+                .with(csrf()))
+        .andExpect(status().isOk());
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_emptyString_on_creating_new_review() throws Exception {
+
+    // Arrange
+    LocalDateTime now = LocalDateTime.now();
+
+    User user = currentUserService.getUser();
+    MenuItem menuItem = MenuItem.builder().id(1L).build();
+
+    Review review =
+        Review.builder()
+            .itemsStars(1l)
+            .reviewerComments(null)
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
+            .reviewer(user)
+            .status(ModerationStatus.APPROVED)
+            .item(menuItem)
+            .build();
+
+    Review reviewReturn =
+        Review.builder()
+            .dateCreated(now)
+            .dateEdited(now)
+            .itemsStars(1l)
+            .reviewerComments(null)
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
+            .reviewer(user)
+            .status(ModerationStatus.APPROVED)
+            .item(menuItem)
+            .id(0L)
+            .build();
+    when(reviewRepository.save(eq(review))).thenReturn(reviewReturn);
+
+    // Act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/reviews/post?itemId=1&reviewerComments=&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String jsonReview = mapper.writeValueAsString(reviewReturn);
+
+    // Assert
+    verify(reviewRepository).save(any(Review.class));
+    String responseJson = response.getResponse().getContentAsString();
+
+    assertEquals(jsonReview, responseJson);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_no_string_on_creating_new_review() throws Exception {
+
+    // Arrange
+    LocalDateTime now = LocalDateTime.now();
+
+    User user = currentUserService.getUser();
+    MenuItem menuItem = MenuItem.builder().id(1L).build();
+
+    Review review =
+        Review.builder()
+            .itemsStars(1l)
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
+            .reviewer(user)
+            .status(ModerationStatus.APPROVED)
+            .item(menuItem)
+            .build();
+
+    Review reviewReturn =
+        Review.builder()
+            .dateCreated(now)
+            .dateEdited(now)
+            .itemsStars(1l)
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
+            .reviewer(user)
+            .status(ModerationStatus.APPROVED)
+            .item(menuItem)
+            .id(0L)
+            .build();
+    when(reviewRepository.save(eq(review))).thenReturn(reviewReturn);
+
+    // Act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/reviews/post?itemId=1&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // Assert
+    verify(reviewRepository).save(any(Review.class));
+    String responseJson = response.getResponse().getContentAsString();
+    String reviewJson = mapper.writeValueAsString(reviewReturn);
+    assertEquals(responseJson, reviewJson);
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void a_logged_in_admin_can_get_all() throws Exception {
+    // Arrange
+
+    LocalDateTime now = LocalDateTime.now();
+
+    User user1 = currentUserService.getUser();
+    User user2 = User.builder().id(2L).build();
+    MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+    MenuItem menuItem2 = MenuItem.builder().id(313L).build();
+
+    Review review1 =
+        Review.builder()
+            .dateCreated(now)
+            .dateEdited(now)
+            .itemsStars(3l)
+            .reviewerComments("Im tired of this same chicken")
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
+            .reviewer(user1)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(0L)
+            .build();
+
+    Review review2 =
+        Review.builder()
+            .dateCreated(now.plusDays(4))
+            .dateEdited(now.plusDays(5))
+            .itemsStars(5l)
+            .reviewerComments("MMMMM I LOVE CHICKEN")
+            .dateItemServed(LocalDateTime.of(2022, 7, 1, 8, 8, 8))
+            .reviewer(user2)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem2)
+            .id(0L)
+            .build();
+
+    Review review3 =
+        Review.builder()
+            .dateCreated(now)
+            .dateEdited(now)
+            .itemsStars(6l)
+            .reviewerComments("Im tired of this same chicken")
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
+            .reviewer(user1)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem2)
+            .id(0L)
+            .build();
+
+    ArrayList<Review> reviews = new ArrayList<>();
+    reviews.addAll(Arrays.asList(review1, review2, review3));
+
+    when(reviewRepository.findAll()).thenReturn(reviews);
+    // Act
+    MvcResult response =
+        mockMvc.perform(get("/api/reviews/all")).andExpect(status().is(200)).andReturn();
+
+    // assert
+    verify(reviewRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(reviews);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void a_logged_in_user_can_get_own_reviews_list() throws Exception {
+    // Arrange
+    User user1 = currentUserService.getUser();
+    User user2 = User.builder().id(2L).build();
+
+    MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+    MenuItem menuItem2 = MenuItem.builder().id(313L).build();
+
+    Review review1 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user1)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    Review review2 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 4, 28, 1, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 6, 47))
+            .dateItemServed(LocalDateTime.of(2022, 2, 6, 8, 8))
+            .reviewer(user2)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(2L)
+            .build();
+
+    Review review3 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 2, 17, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 12, 15, 04, 26))
+            .dateItemServed(LocalDateTime.of(2023, 1, 7, 3, 8))
+            .reviewer(user2)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem2)
+            .id(3L)
+            .build();
+
+    ArrayList<Review> reviews = new ArrayList<>();
+    ArrayList<Review> valid_reviews = new ArrayList<>();
+    valid_reviews.addAll(Arrays.asList(review1));
+    reviews.addAll(Arrays.asList(review1, review2, review3));
+    when(reviewRepository.findByReviewer(eq(user1))).thenReturn(valid_reviews);
+
+    // Act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/reviews/userReviews").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(reviewRepository, times(1)).findByReviewer(eq(user1));
+    String expectedJson = mapper.writeValueAsString(valid_reviews);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void testItemIdIsInvalid_NotFound() throws Exception {
+
+    // Act: Perform the request and expect the review creation to fail due to non-existing itemId
+    mockMvc
+        .perform(
+            post("/api/reviews/post")
+                .param("itemId", "5") // This itemId does not exist
+                .param("reviewerComments", "")
+                .param("itemsStars", "1")
+                .param("dateItemServed", "2021-12-12T08:08:08")
+                .with(csrf()))
+        .andExpect(status().isNotFound())
+        .andExpect(
+            result -> assertTrue(result.getResolvedException() instanceof EntityNotFoundException))
+        .andExpect(
+            result ->
+                assertEquals(
+                    "MenuItem with id 5 not found", result.getResolvedException().getMessage()));
+
+    // Assert: Ensure no reviews are saved due to invalid itemId
+    verify(reviewRepository, times(0)).save(any(Review.class));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void wrong_user_cannot_edit() throws Exception {
+    User user2 = User.builder().id(2L).build();
+
+    MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+    Review review1 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user2)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    EditedReview reviewEdit =
+        EditedReview.builder()
+            .reviewerComments("test")
+            .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+            .itemStars(2L)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(reviewEdit);
+
+    when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/reviews/reviewer")
+                    .param("id", "1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isForbidden())
+            .andReturn();
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void cannot_set_stars_over_boundaries() throws Exception {
+    User user1 = currentUserService.getUser();
+
+    MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+    Review review1 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user1)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    EditedReview reviewTooLow =
+        EditedReview.builder()
+            .reviewerComments("test")
+            .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+            .itemStars(0L)
+            .build();
+
+    EditedReview reviewTooHigh =
+        EditedReview.builder()
+            .reviewerComments("test")
+            .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+            .itemStars(6L)
+            .build();
+
+    String requestBodyTooLow = mapper.writeValueAsString(reviewTooLow);
+    String requestBodyTooHigh = mapper.writeValueAsString(reviewTooHigh);
+
+    when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+
+    mockMvc
+        .perform(
+            put("/api/reviews/reviewer")
                 .param("id", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("utf-8")
                 .content(requestBodyTooLow)
-                .with(csrf())).andExpect(status().isBadRequest()).andReturn();
-        mockMvc.perform(put("/api/reviews/reviewer")
+                .with(csrf()))
+        .andExpect(status().isBadRequest())
+        .andReturn();
+    mockMvc
+        .perform(
+            put("/api/reviews/reviewer")
                 .param("id", "1")
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("utf-8")
                 .content(requestBodyTooHigh)
-                .with(csrf())).andExpect(status().isBadRequest()).andReturn();
-    }
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void can_set_stars_at_low_boundary() throws Exception{
-        User user1 = currentUserService.getUser();
-
-        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
-
-        Review review1 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user1)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-        EditedReview review = EditedReview.builder()
-                .reviewerComments("test")
-                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
-                .itemStars(1L)
-                .build();
-
-        String requestBody = mapper.writeValueAsString(review);
-
-
-        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
-
-        mockMvc.perform(put("/api/reviews/reviewer")
-                .param("id", "1")
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding("utf-8")
-                .content(requestBody)
-                .with(csrf())).andExpect(status().isOk()).andReturn();
-    }
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void can_set_stars_at_high_boundary() throws Exception{
-        User user1 = currentUserService.getUser();
-
-        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
-
-        Review review1 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user1)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-        EditedReview review = EditedReview.builder()
-                .reviewerComments("test")
-                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
-                .itemStars(5L)
-                .build();
-
-        String requestBody = mapper.writeValueAsString(review);
-
-
-        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
-
-        mockMvc.perform(put("/api/reviews/reviewer")
-                .param("id", "1")
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding("utf-8")
-                .content(requestBody)
-                .with(csrf())).andExpect(status().isOk()).andReturn();
-    }
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void trim_works_correctly() throws Exception{
-        User user1 = currentUserService.getUser();
-
-        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
-
-        Review review1 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user1)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-        EditedReview reviewEdit = EditedReview.builder()
-                .reviewerComments("   ")
-                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
-                .itemStars(2L)
-                .build();
-
-        Review reviewResponse = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
-                .reviewer(user1)
-                .reviewerComments(null)
-                .itemsStars(2L)
-                .status(ModerationStatus.APPROVED)
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
-        when(reviewRepository.save(eq(reviewResponse))).thenReturn(reviewResponse);
-
-
-        String requestBody = mapper.writeValueAsString(reviewEdit);
-
-        MvcResult response = mockMvc.perform(put("/api/reviews/reviewer")
-                .param("id", "1")
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding("utf-8")
-                .content(requestBody)
-                .with(csrf())).andExpect(status().isOk()).andReturn();
-
-        String reviewJson = mapper.writeValueAsString(reviewResponse);
-        String responseJson = response.getResponse().getContentAsString();
-        verify(reviewRepository, times(1)).findById(eq(1L));
-        verify(reviewRepository, times(1)).save(eq(reviewResponse));
-        assertEquals(responseJson, reviewJson);
-    }
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void null_works_correctly() throws Exception{
-        User user1 = currentUserService.getUser();
-
-        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
-
-        Review review1 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user1)
-                .reviewerComments("there is a comment here.")
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-        EditedReview reviewEdit = EditedReview.builder()
-                .reviewerComments(null)
-                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
-                .itemStars(2L)
-                .build();
-
-        Review reviewResponse = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
-                .reviewer(user1)
-                .reviewerComments(null)
-                .itemsStars(2L)
-                .status(ModerationStatus.APPROVED)
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
-        when(reviewRepository.save(eq(reviewResponse))).thenReturn(reviewResponse);
-
-
-        String requestBody = mapper.writeValueAsString(reviewEdit);
-
-        MvcResult response = mockMvc.perform(put("/api/reviews/reviewer")
-                .param("id", "1")
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding("utf-8")
-                .content(requestBody)
-                .with(csrf())).andExpect(status().isOk()).andReturn();
-
-        String reviewJson = mapper.writeValueAsString(reviewResponse);
-        String responseJson = response.getResponse().getContentAsString();
-        verify(reviewRepository, times(1)).findById(eq(1L));
-        verify(reviewRepository, times(1)).save(eq(reviewResponse));
-        assertEquals(responseJson, reviewJson);
-    }
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void edit_works_correctly() throws Exception{
-        User user1 = currentUserService.getUser();
-
-        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
-
-        Review review1 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user1)
-                .status(ModerationStatus.REJECTED)
-                .moderatorComments("unacceptable")
-                .item(menuItem1)
-                .itemsStars(3L)
-                .id(1L)
-                .build();
-
-        EditedReview reviewEdit = EditedReview.builder()
-                .reviewerComments("test")
-                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
-                .itemStars(2L)
-                .build();
-
-        Review reviewResponse = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
-                .reviewer(user1)
-                .reviewerComments("test")
-                .itemsStars(2L)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
-        when(reviewRepository.save(eq(reviewResponse))).thenReturn(reviewResponse);
-
-
-        String requestBody = mapper.writeValueAsString(reviewEdit);
-
-        MvcResult response = mockMvc.perform(put("/api/reviews/reviewer")
-                .param("id", "1")
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding("utf-8")
-                .content(requestBody)
-                .with(csrf())).andExpect(status().isOk()).andReturn();
-
-        String reviewJson = mapper.writeValueAsString(reviewResponse);
-        String responseJson = response.getResponse().getContentAsString();
-        verify(reviewRepository, times(1)).findById(eq(1L));
-        verify(reviewRepository, times(1)).save(eq(reviewResponse));
-        assertEquals(responseJson, reviewJson);
-    }
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void not_found_throws_exception() throws Exception{
-        EditedReview reviewEdit = EditedReview.builder()
-                .reviewerComments("test")
-                .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
-                .itemStars(2L)
-                .build();
-
-        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.empty());
-
-        String requestBody = mapper.writeValueAsString(reviewEdit);
-
-        MvcResult response = mockMvc.perform(put("/api/reviews/reviewer")
-                .param("id", "1")
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding("utf-8")
-                .content(requestBody)
-                .with(csrf())).andExpect(status().isNotFound()).andReturn();
-
-        verify(reviewRepository, times(1)).findById(eq(1L));
-        Map<String, Object> json = responseToJson(response);
-        assertEquals("Review with id 1 not found", json.get("message"));
-
-    }
-
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void wrong_user_cannot_delete() throws Exception{
-        User user2 = User.builder().id(2L).build();
-
-        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
-
-        Review review1 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user2)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-
-        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
-
-        MvcResult response = mockMvc.perform(delete("/api/reviews/reviewer")
-                .param("id", "1")
-                .with(csrf())).andExpect(status().isForbidden()).andReturn();
-
-        verify(reviewRepository, times(0)).delete(eq(review1));
-    }
-
-    @WithMockUser(roles = {"ADMIN","USER"})
-    @Test
-    public void admin_can_delete() throws Exception{
-        User user2 = User.builder().id(2L).build();
-
-        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
-
-        Review review1 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user2)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-
-        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
-
-        MvcResult response = mockMvc.perform(delete("/api/reviews/reviewer")
-                .param("id", "1")
-                .with(csrf())).andExpect(status().isOk()).andReturn();
-
-        verify(reviewRepository, times(1)).delete(eq(review1));
-        Map<String, Object> json = responseToJson(response);
-        assertEquals("Review with id 1 deleted", json.get("message"));
-    }
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void user_can_delete() throws Exception{
-        User user1 = currentUserService.getUser();
-
-        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
-
-        Review review1 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user1)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-
-        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
-
-        MvcResult response = mockMvc.perform(delete("/api/reviews/reviewer")
-                .param("id", "1")
-                .with(csrf())).andExpect(status().isOk()).andReturn();
-
-        verify(reviewRepository, times(1)).delete(eq(review1));
-        Map<String, Object> json = responseToJson(response);
-        assertEquals("Review with id 1 deleted", json.get("message"));
-    }
-
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void nonexistent_cannot_delete() throws Exception{
-        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.empty());
-
-        MvcResult response = mockMvc.perform(delete("/api/reviews/reviewer")
-                .param("id", "1")
-                .with(csrf())).andExpect(status().isNotFound()).andReturn();
-
-        Map<String, Object> json = responseToJson(response);
-        assertEquals("Review with id 1 not found", json.get("message"));
-    }
-
-    @WithMockUser(roles = {"MODERATOR"})
-    @Test
-    public void moderator_can_moderate_a_review() throws Exception{
-        User user1 = User.builder().id(2L).build();
-
-        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
-
-        Review review1 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user1)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-        Review approved = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user1)
-                .status(ModerationStatus.APPROVED)
-                .moderatorComments("acceptable")
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
-        when(reviewRepository.save(eq(approved))).thenReturn(approved);
-
-        MvcResult response = mockMvc.perform(put("/api/reviews/moderate")
-            .param("id", "1")
-            .param("status", "APPROVED")
-            .param("moderatorComments", "acceptable")
-            .with(csrf()))
-            .andExpect(status().isOk()).andReturn();
-
-        String jsonExpected = mapper.writeValueAsString(approved);
-        String jsonResponse = response.getResponse().getContentAsString();
-        verify(reviewRepository, times(1)).findById(eq(1L));
-        verify(reviewRepository, times(1)).save(eq(approved));
-        assertEquals(jsonExpected, jsonResponse);
-    }
-
-    @WithMockUser(roles = {"ADMIN"})
-    @Test
-    public void admin_can_moderate_a_review() throws Exception{
-        User user1 = User.builder().id(2L).build();
-
-        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
-
-        Review review1 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user1)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-        Review approved = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user1)
-                .status(ModerationStatus.APPROVED)
-                .moderatorComments("acceptable")
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
-        when(reviewRepository.save(eq(approved))).thenReturn(approved);
-
-        MvcResult response = mockMvc.perform(put("/api/reviews/moderate")
-            .param("id", "1")
-            .param("status", "APPROVED")
-            .param("moderatorComments", "acceptable")
-            .with(csrf()))
-            .andExpect(status().isOk()).andReturn();
-
-        String jsonExpected = mapper.writeValueAsString(approved);
-        String jsonResponse = response.getResponse().getContentAsString();
-        verify(reviewRepository, times(1)).findById(eq(1L));
-        verify(reviewRepository, times(1)).save(eq(approved));
-        assertEquals(jsonExpected, jsonResponse);
-    }
-
-    @WithMockUser(roles = {"MODERATOR"})
-    @Test
-    public void moderator_nonexistent_cannot_approve() throws Exception{
-        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.empty());
-
-        MvcResult response = mockMvc.perform(put("/api/reviews/moderate")
-                .param("id", "1")
-                .param("status", "APPROVED")
-                .param("moderatorComments", "acceptable")
-                .with(csrf())).andExpect(status().isNotFound()).andReturn();
-
-        Map<String, Object> json = responseToJson(response);
-        assertEquals("Review with id 1 not found", json.get("message"));
-    }
-
-    @WithMockUser(roles = {"ADMIN"})
-    @Test
-    public void admin_nonexistent_cannot_approve() throws Exception{
-        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.empty());
-
-        MvcResult response = mockMvc.perform(put("/api/reviews/moderate")
-                .param("id", "1")
-                .param("status", "APPROVED")
-                .param("moderatorComments", "acceptable")
-                .with(csrf())).andExpect(status().isNotFound()).andReturn();
-
-        Map<String, Object> json = responseToJson(response);
-        assertEquals("Review with id 1 not found", json.get("message"));
-    }
-
-    @WithMockUser(roles = {"MODERATOR"})
-    @Test
-    public void moderator_get_needs_moderation_returns_moderation_needed() throws Exception{
-        User user1 = User.builder().id(2L).build();
-
-        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
-
-        Review review1 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user1)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(1L)
-                .build();
-
-        Review review2 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user1)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(2L)
-                .build();
-
-
-        ArrayList<Review> returnableReviews = new ArrayList<>(Arrays.asList(review1, review2));
-
-        when(reviewRepository.findByStatus(eq(ModerationStatus.AWAITING_REVIEW))).thenReturn(returnableReviews);
-
-        MvcResult response = mockMvc.perform(get("/api/reviews/needsmoderation")
                 .with(csrf()))
-                .andExpect(status().isOk()).andReturn();
+        .andExpect(status().isBadRequest())
+        .andReturn();
+  }
 
-        String expectedJson = mapper.writeValueAsString(returnableReviews);
-        String responseJson = response.getResponse().getContentAsString();
-        verify(reviewRepository, times(1)).findByStatus(eq(ModerationStatus.AWAITING_REVIEW));
-        assertEquals(expectedJson,responseJson);
-    }
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void can_set_stars_at_low_boundary() throws Exception {
+    User user1 = currentUserService.getUser();
 
-    @WithMockUser(roles = {"ADMIN"})
-    @Test
-    public void admin_get_needs_moderation_returns_moderation_needed() throws Exception{
-        User user1 = User.builder().id(2L).build();
+    MenuItem menuItem1 = MenuItem.builder().id(1L).build();
 
-        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+    Review review1 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user1)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(1L)
+            .build();
 
-        Review review1 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user1)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(1L)
-                .build();
+    EditedReview review =
+        EditedReview.builder()
+            .reviewerComments("test")
+            .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+            .itemStars(1L)
+            .build();
 
-        Review review2 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user1)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(2L)
-                .build();
+    String requestBody = mapper.writeValueAsString(review);
 
+    when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
 
-        ArrayList<Review> returnableReviews = new ArrayList<>(Arrays.asList(review1, review2));
-
-        when(reviewRepository.findByStatus(eq(ModerationStatus.AWAITING_REVIEW))).thenReturn(returnableReviews);
-
-        MvcResult response = mockMvc.perform(get("/api/reviews/needsmoderation")
+    mockMvc
+        .perform(
+            put("/api/reviews/reviewer")
+                .param("id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
                 .with(csrf()))
-                .andExpect(status().isOk()).andReturn();
+        .andExpect(status().isOk())
+        .andReturn();
+  }
 
-        String expectedJson = mapper.writeValueAsString(returnableReviews);
-        String responseJson = response.getResponse().getContentAsString();
-        verify(reviewRepository, times(1)).findByStatus(eq(ModerationStatus.AWAITING_REVIEW));
-        assertEquals(expectedJson,responseJson);
-    }
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void can_set_stars_at_high_boundary() throws Exception {
+    User user1 = currentUserService.getUser();
 
+    MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+    Review review1 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user1)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    EditedReview review =
+        EditedReview.builder()
+            .reviewerComments("test")
+            .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+            .itemStars(5L)
+            .build();
+
+    String requestBody = mapper.writeValueAsString(review);
+
+    when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+
+    mockMvc
+        .perform(
+            put("/api/reviews/reviewer")
+                .param("id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andReturn();
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void trim_works_correctly() throws Exception {
+    User user1 = currentUserService.getUser();
+
+    MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+    Review review1 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user1)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    EditedReview reviewEdit =
+        EditedReview.builder()
+            .reviewerComments("   ")
+            .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+            .itemStars(2L)
+            .build();
+
+    Review reviewResponse =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+            .reviewer(user1)
+            .reviewerComments(null)
+            .itemsStars(2L)
+            .status(ModerationStatus.APPROVED)
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+    when(reviewRepository.save(eq(reviewResponse))).thenReturn(reviewResponse);
+
+    String requestBody = mapper.writeValueAsString(reviewEdit);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/reviews/reviewer")
+                    .param("id", "1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String reviewJson = mapper.writeValueAsString(reviewResponse);
+    String responseJson = response.getResponse().getContentAsString();
+    verify(reviewRepository, times(1)).findById(eq(1L));
+    verify(reviewRepository, times(1)).save(eq(reviewResponse));
+    assertEquals(responseJson, reviewJson);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void null_works_correctly() throws Exception {
+    User user1 = currentUserService.getUser();
+
+    MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+    Review review1 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user1)
+            .reviewerComments("there is a comment here.")
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    EditedReview reviewEdit =
+        EditedReview.builder()
+            .reviewerComments(null)
+            .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+            .itemStars(2L)
+            .build();
+
+    Review reviewResponse =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+            .reviewer(user1)
+            .reviewerComments(null)
+            .itemsStars(2L)
+            .status(ModerationStatus.APPROVED)
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+    when(reviewRepository.save(eq(reviewResponse))).thenReturn(reviewResponse);
+
+    String requestBody = mapper.writeValueAsString(reviewEdit);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/reviews/reviewer")
+                    .param("id", "1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String reviewJson = mapper.writeValueAsString(reviewResponse);
+    String responseJson = response.getResponse().getContentAsString();
+    verify(reviewRepository, times(1)).findById(eq(1L));
+    verify(reviewRepository, times(1)).save(eq(reviewResponse));
+    assertEquals(responseJson, reviewJson);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void edit_works_correctly() throws Exception {
+    User user1 = currentUserService.getUser();
+
+    MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+    Review review1 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user1)
+            .status(ModerationStatus.REJECTED)
+            .moderatorComments("unacceptable")
+            .item(menuItem1)
+            .itemsStars(3L)
+            .id(1L)
+            .build();
+
+    EditedReview reviewEdit =
+        EditedReview.builder()
+            .reviewerComments("test")
+            .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+            .itemStars(2L)
+            .build();
+
+    Review reviewResponse =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+            .reviewer(user1)
+            .reviewerComments("test")
+            .itemsStars(2L)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+    when(reviewRepository.save(eq(reviewResponse))).thenReturn(reviewResponse);
+
+    String requestBody = mapper.writeValueAsString(reviewEdit);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/reviews/reviewer")
+                    .param("id", "1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String reviewJson = mapper.writeValueAsString(reviewResponse);
+    String responseJson = response.getResponse().getContentAsString();
+    verify(reviewRepository, times(1)).findById(eq(1L));
+    verify(reviewRepository, times(1)).save(eq(reviewResponse));
+    assertEquals(responseJson, reviewJson);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void not_found_throws_exception() throws Exception {
+    EditedReview reviewEdit =
+        EditedReview.builder()
+            .reviewerComments("test")
+            .dateItemServed(LocalDateTime.of(2022, 1, 1, 0, 0))
+            .itemStars(2L)
+            .build();
+
+    when(reviewRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+    String requestBody = mapper.writeValueAsString(reviewEdit);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/reviews/reviewer")
+                    .param("id", "1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    verify(reviewRepository, times(1)).findById(eq(1L));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("Review with id 1 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void wrong_user_cannot_delete() throws Exception {
+    User user2 = User.builder().id(2L).build();
+
+    MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+    Review review1 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user2)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/reviews/reviewer").param("id", "1").with(csrf()))
+            .andExpect(status().isForbidden())
+            .andReturn();
+
+    verify(reviewRepository, times(0)).delete(eq(review1));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_delete() throws Exception {
+    User user2 = User.builder().id(2L).build();
+
+    MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+    Review review1 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user2)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/reviews/reviewer").param("id", "1").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(reviewRepository, times(1)).delete(eq(review1));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("Review with id 1 deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void user_can_delete() throws Exception {
+    User user1 = currentUserService.getUser();
+
+    MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+    Review review1 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user1)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/reviews/reviewer").param("id", "1").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    verify(reviewRepository, times(1)).delete(eq(review1));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("Review with id 1 deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void nonexistent_cannot_delete() throws Exception {
+    when(reviewRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/reviews/reviewer").param("id", "1").with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("Review with id 1 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"MODERATOR"})
+  @Test
+  public void moderator_can_moderate_a_review() throws Exception {
+    User user1 = User.builder().id(2L).build();
+
+    MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+    Review review1 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user1)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    Review approved =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user1)
+            .status(ModerationStatus.APPROVED)
+            .moderatorComments("acceptable")
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+    when(reviewRepository.save(eq(approved))).thenReturn(approved);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/reviews/moderate")
+                    .param("id", "1")
+                    .param("status", "APPROVED")
+                    .param("moderatorComments", "acceptable")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String jsonExpected = mapper.writeValueAsString(approved);
+    String jsonResponse = response.getResponse().getContentAsString();
+    verify(reviewRepository, times(1)).findById(eq(1L));
+    verify(reviewRepository, times(1)).save(eq(approved));
+    assertEquals(jsonExpected, jsonResponse);
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_can_moderate_a_review() throws Exception {
+    User user1 = User.builder().id(2L).build();
+
+    MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+    Review review1 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user1)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    Review approved =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user1)
+            .status(ModerationStatus.APPROVED)
+            .moderatorComments("acceptable")
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+    when(reviewRepository.save(eq(approved))).thenReturn(approved);
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/reviews/moderate")
+                    .param("id", "1")
+                    .param("status", "APPROVED")
+                    .param("moderatorComments", "acceptable")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String jsonExpected = mapper.writeValueAsString(approved);
+    String jsonResponse = response.getResponse().getContentAsString();
+    verify(reviewRepository, times(1)).findById(eq(1L));
+    verify(reviewRepository, times(1)).save(eq(approved));
+    assertEquals(jsonExpected, jsonResponse);
+  }
+
+  @WithMockUser(roles = {"MODERATOR"})
+  @Test
+  public void moderator_nonexistent_cannot_approve() throws Exception {
+    when(reviewRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/reviews/moderate")
+                    .param("id", "1")
+                    .param("status", "APPROVED")
+                    .param("moderatorComments", "acceptable")
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("Review with id 1 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_nonexistent_cannot_approve() throws Exception {
+    when(reviewRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/reviews/moderate")
+                    .param("id", "1")
+                    .param("status", "APPROVED")
+                    .param("moderatorComments", "acceptable")
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("Review with id 1 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"MODERATOR"})
+  @Test
+  public void moderator_get_needs_moderation_returns_moderation_needed() throws Exception {
+    User user1 = User.builder().id(2L).build();
+
+    MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+    Review review1 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user1)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    Review review2 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user1)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(2L)
+            .build();
+
+    ArrayList<Review> returnableReviews = new ArrayList<>(Arrays.asList(review1, review2));
+
+    when(reviewRepository.findByStatus(eq(ModerationStatus.AWAITING_REVIEW)))
+        .thenReturn(returnableReviews);
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/reviews/needsmoderation").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String expectedJson = mapper.writeValueAsString(returnableReviews);
+    String responseJson = response.getResponse().getContentAsString();
+    verify(reviewRepository, times(1)).findByStatus(eq(ModerationStatus.AWAITING_REVIEW));
+    assertEquals(expectedJson, responseJson);
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_get_needs_moderation_returns_moderation_needed() throws Exception {
+    User user1 = User.builder().id(2L).build();
+
+    MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+    Review review1 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user1)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(1L)
+            .build();
+
+    Review review2 =
+        Review.builder()
+            .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+            .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+            .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+            .reviewer(user1)
+            .status(ModerationStatus.AWAITING_REVIEW)
+            .item(menuItem1)
+            .id(2L)
+            .build();
+
+    ArrayList<Review> returnableReviews = new ArrayList<>(Arrays.asList(review1, review2));
+
+    when(reviewRepository.findByStatus(eq(ModerationStatus.AWAITING_REVIEW)))
+        .thenReturn(returnableReviews);
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/reviews/needsmoderation").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String expectedJson = mapper.writeValueAsString(returnableReviews);
+    String responseJson = response.getResponse().getContentAsString();
+    verify(reviewRepository, times(1)).findByStatus(eq(ModerationStatus.AWAITING_REVIEW));
+    assertEquals(expectedJson, responseJson);
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/SystemInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/SystemInfoControllerTests.java
@@ -1,49 +1,43 @@
 package edu.ucsb.cs156.dining.controllers;
 
-import edu.ucsb.cs156.dining.ControllerTestCase;
-import edu.ucsb.cs156.dining.models.SystemInfo;
-import edu.ucsb.cs156.dining.repositories.UserRepository;
-import edu.ucsb.cs156.dining.services.SystemInfoService;
-
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.web.servlet.MvcResult;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import edu.ucsb.cs156.dining.ControllerTestCase;
+import edu.ucsb.cs156.dining.models.SystemInfo;
+import edu.ucsb.cs156.dining.repositories.UserRepository;
+import edu.ucsb.cs156.dining.services.SystemInfoService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MvcResult;
+
 @WebMvcTest(controllers = SystemInfoController.class)
 public class SystemInfoControllerTests extends ControllerTestCase {
 
-  @MockBean
-  UserRepository userRepository;
+  @MockBean UserRepository userRepository;
 
-  @MockBean
-  SystemInfoService mockSystemInfoService;
-
+  @MockBean SystemInfoService mockSystemInfoService;
 
   @Test
   public void systemInfo__admin_logged_in() throws Exception {
 
     // arrange
 
-
-    SystemInfo systemInfo = SystemInfo
-        .builder()
-        .showSwaggerUILink(true)
-        .springH2ConsoleEnabled(true)
-        .oauthLogin("/oauth2/authorization/google")
-        .build();
+    SystemInfo systemInfo =
+        SystemInfo.builder()
+            .showSwaggerUILink(true)
+            .springH2ConsoleEnabled(true)
+            .oauthLogin("/oauth2/authorization/google")
+            .build();
     when(mockSystemInfoService.getSystemInfo()).thenReturn(systemInfo);
     String expectedJson = mapper.writeValueAsString(systemInfo);
 
     // act
-    MvcResult response = mockMvc.perform(get("/api/systemInfo"))
-        .andExpect(status().isOk()).andReturn();
+    MvcResult response =
+        mockMvc.perform(get("/api/systemInfo")).andExpect(status().isOk()).andReturn();
 
     // assert
     String responseString = response.getResponse().getContentAsString();

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuControllerTests.java
@@ -8,19 +8,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import edu.ucsb.cs156.dining.ControllerTestCase;
 import edu.ucsb.cs156.dining.config.SecurityConfig;
-import edu.ucsb.cs156.dining.repositories.UserRepository;
 import edu.ucsb.cs156.dining.services.UCSBDiningMenuService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-import java.time.LocalDateTime;
-import java.util.List;
 
 @WebMvcTest(value = UCSBDiningMenuController.class)
 @Import(SecurityConfig.class)

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/UserInfoControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/UserInfoControllerTests.java
@@ -1,10 +1,13 @@
 package edu.ucsb.cs156.dining.controllers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 import edu.ucsb.cs156.dining.ControllerTestCase;
 import edu.ucsb.cs156.dining.models.CurrentUser;
 import edu.ucsb.cs156.dining.repositories.UserRepository;
 import edu.ucsb.cs156.dining.testconfig.TestConfig;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -12,24 +15,18 @@ import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 @WebMvcTest(controllers = UserInfoController.class)
 @Import(TestConfig.class)
 public class UserInfoControllerTests extends ControllerTestCase {
 
-  @MockBean
-  UserRepository userRepository;
+  @MockBean UserRepository userRepository;
 
   @Test
   public void currentUser__logged_out() throws Exception {
-    mockMvc.perform(get("/api/currentUser"))
-        .andExpect(status().is(403));
+    mockMvc.perform(get("/api/currentUser")).andExpect(status().is(403));
   }
 
-  @WithMockUser(roles = { "USER" })
+  @WithMockUser(roles = {"USER"})
   @Test
   public void currentUser__logged_in() throws Exception {
 
@@ -40,8 +37,8 @@ public class UserInfoControllerTests extends ControllerTestCase {
 
     // act
 
-    MvcResult response = mockMvc.perform(get("/api/currentUser"))
-        .andExpect(status().isOk()).andReturn();
+    MvcResult response =
+        mockMvc.perform(get("/api/currentUser")).andExpect(status().isOk()).andReturn();
 
     // assert
     String responseString = response.getResponse().getContentAsString();

--- a/src/test/java/edu/ucsb/cs156/dining/services/CurrentUserServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/services/CurrentUserServiceTests.java
@@ -5,26 +5,26 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.jupiter.api.Test;
-
 import edu.ucsb.cs156.dining.ControllerTestCase;
 import edu.ucsb.cs156.dining.entities.User;
+import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 
 class CurrentUserServiceTests extends ControllerTestCase {
 
   @Test
   void test_isLoggedIn_returns_false() {
-    CurrentUserService currentUserService = mock(CurrentUserService.class, Answers.CALLS_REAL_METHODS);
+    CurrentUserService currentUserService =
+        mock(CurrentUserService.class, Answers.CALLS_REAL_METHODS);
     when(currentUserService.getUser()).thenReturn(null);
     assertFalse(currentUserService.isLoggedIn());
   }
 
   @Test
   void test_isLoggedIn_returns_true() {
-    CurrentUserService currentUserService = mock(CurrentUserService.class, Answers.CALLS_REAL_METHODS);
+    CurrentUserService currentUserService =
+        mock(CurrentUserService.class, Answers.CALLS_REAL_METHODS);
     when(currentUserService.getUser()).thenReturn(User.builder().build());
     assertTrue(currentUserService.isLoggedIn());
   }
-
 }

--- a/src/test/java/edu/ucsb/cs156/dining/services/DiningCommonsServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/services/DiningCommonsServiceTests.java
@@ -7,7 +7,6 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 import edu.ucsb.cs156.dining.models.DiningCommons;
 import edu.ucsb.cs156.dining.services.wiremock.WiremockService;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -16,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -25,8 +25,7 @@ import org.springframework.test.web.client.MockRestServiceServer;
 @ContextConfiguration(classes = {})
 class DiningCommonsServiceTests {
 
-  @MockBean
-  private WiremockService wiremockService;
+  @MockBean private WiremockService wiremockService;
 
   @Autowired private MockRestServiceServer mockRestServiceServer;
 
@@ -65,13 +64,7 @@ class DiningCommonsServiceTests {
             }
             ]
             """,
-            NAME,
-            CODE,
-            HASDININGCAM,
-            HASSACKMEAL,
-            HASTAKEOUTMEAL,
-            LONGITUDE,
-            LATITUDE);
+            NAME, CODE, HASDININGCAM, HASSACKMEAL, HASTAKEOUTMEAL, LONGITUDE, LATITUDE);
 
     DiningCommons expectedCommons =
         DiningCommons.builder()

--- a/src/test/java/edu/ucsb/cs156/dining/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/services/SystemInfoServiceImplTests.java
@@ -4,14 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import edu.ucsb.cs156.dining.models.SystemInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
-
-import edu.ucsb.cs156.dining.models.SystemInfo;
 
 // The unit under test relies on property values
 // For hints on testing, see: https://www.baeldung.com/spring-boot-testing-configurationproperties
@@ -21,8 +20,7 @@ import edu.ucsb.cs156.dining.models.SystemInfo;
 @TestPropertySource("classpath:application-development.properties")
 class SystemInfoServiceImplTests {
 
-  @Autowired
-  private SystemInfoService systemInfoService;
+  @Autowired private SystemInfoService systemInfoService;
 
   @Test
   void test_getSystemInfo() {

--- a/src/test/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuItemsServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuItemsServiceTests.java
@@ -1,24 +1,22 @@
 package edu.ucsb.cs156.dining.services;
 
-import edu.ucsb.cs156.dining.services.wiremock.WiremockService;
-import edu.ucsb.cs156.dining.models.Entree;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import edu.ucsb.cs156.dining.models.Entree;
+import edu.ucsb.cs156.dining.services.wiremock.WiremockService;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
@@ -32,8 +30,7 @@ public class UCSBDiningMenuItemsServiceTests {
 
   @Autowired private MockRestServiceServer mockRestServiceServer;
 
-  @MockBean
-  private WiremockService wiremockService;
+  @MockBean private WiremockService wiremockService;
 
   @Mock private RestTemplate restTemplate;
 
@@ -64,13 +61,9 @@ public class UCSBDiningMenuItemsServiceTests {
                   }
                 ]
             """,
-            NAME,
-            STATION);
+            NAME, STATION);
 
-    Entree expectedEntree = Entree.builder()
-        .name(NAME)
-        .station(STATION)
-        .build();
+    Entree expectedEntree = Entree.builder().name(NAME).station(STATION).build();
 
     this.mockRestServiceServer
         .expect(requestTo(expectedURL))
@@ -79,7 +72,8 @@ public class UCSBDiningMenuItemsServiceTests {
         .andExpect(header("ucsb-api-key", apiKey))
         .andRespond(withSuccess(expectedResult, MediaType.APPLICATION_JSON));
 
-    List<Entree> actualResult = ucsbDiningMenuItemsService.get(dateTime, diningCommonCode, mealCode);
+    List<Entree> actualResult =
+        ucsbDiningMenuItemsService.get(dateTime, diningCommonCode, mealCode);
     List<Entree> expectedList = new ArrayList<>();
     expectedList.addAll(Arrays.asList(expectedEntree));
     assertEquals(expectedList, actualResult);

--- a/src/test/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/services/UCSBDiningMenuServiceTests.java
@@ -1,21 +1,18 @@
 package edu.ucsb.cs156.dining.services;
 
-import edu.ucsb.cs156.dining.services.wiremock.WiremockService;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import java.util.List;
+import edu.ucsb.cs156.dining.services.wiremock.WiremockService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
@@ -29,8 +26,7 @@ public class UCSBDiningMenuServiceTests {
 
   @Autowired private MockRestServiceServer mockRestServiceServer;
 
-  @MockBean
-  private WiremockService wiremockService;
+  @MockBean private WiremockService wiremockService;
 
   @Mock private RestTemplate restTemplate;
 

--- a/src/test/java/edu/ucsb/cs156/dining/testconfig/MockCurrentUserServiceImpl.java
+++ b/src/test/java/edu/ucsb/cs156/dining/testconfig/MockCurrentUserServiceImpl.java
@@ -2,9 +2,7 @@ package edu.ucsb.cs156.dining.testconfig;
 
 import edu.ucsb.cs156.dining.entities.User;
 import edu.ucsb.cs156.dining.services.CurrentUserServiceImpl;
-
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -24,44 +22,52 @@ public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
     String givenName = "Fake";
     String familyName = "User";
     boolean emailVerified = true;
-    String locale="";
-    String hostedDomain="example.org";
-    boolean admin=false;
-    boolean moderator=false;
+    String locale = "";
+    String hostedDomain = "example.org";
+    boolean admin = false;
+    boolean moderator = false;
 
     org.springframework.security.core.userdetails.User user = null;
-
 
     if (principal instanceof org.springframework.security.core.userdetails.User) {
       user = (org.springframework.security.core.userdetails.User) principal;
       googleSub = "fake_" + user.getUsername();
       email = user.getUsername() + "@example.org";
-      pictureUrl = "https://example.org/" +  user.getUsername() + ".jpg";
+      pictureUrl = "https://example.org/" + user.getUsername() + ".jpg";
       fullName = "Fake " + user.getUsername();
       givenName = "Fake";
       familyName = user.getUsername();
       emailVerified = true;
-      locale="";
-      hostedDomain="example.org";
-      admin= securityContext.getAuthentication().getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"));
-      moderator= securityContext.getAuthentication().getAuthorities().contains(new SimpleGrantedAuthority("ROLE_MODERATOR"));
+      locale = "";
+      hostedDomain = "example.org";
+      admin =
+          securityContext
+              .getAuthentication()
+              .getAuthorities()
+              .contains(new SimpleGrantedAuthority("ROLE_ADMIN"));
+      moderator =
+          securityContext
+              .getAuthentication()
+              .getAuthorities()
+              .contains(new SimpleGrantedAuthority("ROLE_MODERATOR"));
     }
 
-    User u = User.builder()
-    .googleSub(googleSub)
-    .email(email)
-    .pictureUrl(pictureUrl)
-    .fullName(fullName)
-    .givenName(givenName)
-    .familyName(familyName)
-    .emailVerified(emailVerified)
-    .locale(locale)
-    .hostedDomain(hostedDomain)
-    .admin(admin)
-    .moderator(moderator)
-    .id(1L)
-    .build();
-    
+    User u =
+        User.builder()
+            .googleSub(googleSub)
+            .email(email)
+            .pictureUrl(pictureUrl)
+            .fullName(fullName)
+            .givenName(givenName)
+            .familyName(familyName)
+            .emailVerified(emailVerified)
+            .locale(locale)
+            .hostedDomain(hostedDomain)
+            .admin(admin)
+            .moderator(moderator)
+            .id(1L)
+            .build();
+
     return u;
   }
 
@@ -75,5 +81,4 @@ public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
 
     return null;
   }
-
 }

--- a/src/test/java/edu/ucsb/cs156/dining/testconfig/TestConfig.java
+++ b/src/test/java/edu/ucsb/cs156/dining/testconfig/TestConfig.java
@@ -1,13 +1,11 @@
 package edu.ucsb.cs156.dining.testconfig;
 
 import edu.ucsb.cs156.dining.config.SecurityConfig;
+import edu.ucsb.cs156.dining.services.CurrentUserService;
+import edu.ucsb.cs156.dining.services.GrantedAuthoritiesService;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-
-
-import edu.ucsb.cs156.dining.services.CurrentUserService;
-import edu.ucsb.cs156.dining.services.GrantedAuthoritiesService;
 import org.springframework.context.annotation.Import;
 
 @TestConfiguration
@@ -15,13 +13,13 @@ import org.springframework.context.annotation.Import;
 @AutoConfigureDataJpa
 public class TestConfig {
 
-    @Bean
-    public CurrentUserService currentUserService() {
-        return new MockCurrentUserServiceImpl();
-    }
+  @Bean
+  public CurrentUserService currentUserService() {
+    return new MockCurrentUserServiceImpl();
+  }
 
-    @Bean
-    public GrantedAuthoritiesService grantedAuthoritiesService() {
-        return new GrantedAuthoritiesService();
-    }
+  @Bean
+  public GrantedAuthoritiesService grantedAuthoritiesService() {
+    return new GrantedAuthoritiesService();
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/dining/web/HomePageWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/dining/web/HomePageWebIT.java
@@ -1,5 +1,12 @@
 package edu.ucsb.cs156.dining.web;
 
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,46 +17,39 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import com.microsoft.playwright.Browser;
-import com.microsoft.playwright.BrowserContext;
-import com.microsoft.playwright.BrowserType;
-import com.microsoft.playwright.Page;
-import com.microsoft.playwright.Playwright;
-import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ActiveProfiles("integration")
 public class HomePageWebIT {
-    @Value("${app.playwright.headless:true}")
-    private boolean runHeadless;
+  @Value("${app.playwright.headless:true}")
+  private boolean runHeadless;
 
-    @LocalServerPort
-    private int port;
+  @LocalServerPort private int port;
 
-    private Browser browser;
-    private Page page;
+  private Browser browser;
+  private Page page;
 
-    @BeforeEach
-    public void setup() {
-        browser = Playwright.create().chromium().launch(new BrowserType.LaunchOptions().setHeadless(runHeadless));
+  @BeforeEach
+  public void setup() {
+    browser =
+        Playwright.create()
+            .chromium()
+            .launch(new BrowserType.LaunchOptions().setHeadless(runHeadless));
 
-        BrowserContext context = browser.newContext();
-        page = context.newPage();
-    }
+    BrowserContext context = browser.newContext();
+    page = context.newPage();
+  }
 
-    @AfterEach
-    public void teardown() {
-        browser.close();
-    }
+  @AfterEach
+  public void teardown() {
+    browser.close();
+  }
 
-    @Test
-    public void home_page_shows_greeting() throws Exception {
-        String url = String.format("http://localhost:%d/", port);
-        page.navigate(url);
+  @Test
+  public void home_page_shows_greeting() throws Exception {
+    String url = String.format("http://localhost:%d/", port);
+    page.navigate(url);
 
-        assertThat(page.getByText("Dining Commons"))
-                .isVisible();
-    }
-
+    assertThat(page.getByText("Dining Commons")).isVisible();
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/dining/web/OauthWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/dining/web/OauthWebIT.java
@@ -1,5 +1,8 @@
 package edu.ucsb.cs156.dining.web;
 
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import edu.ucsb.cs156.dining.WebTestCase;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -8,25 +11,21 @@ import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
-
-import edu.ucsb.cs156.dining.WebTestCase;
-
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ActiveProfiles("integration")
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 public class OauthWebIT extends WebTestCase {
-    @Test
-    public void regular_user_can_login_logout() throws Exception {
-        setupUser(false);
+  @Test
+  public void regular_user_can_login_logout() throws Exception {
+    setupUser(false);
 
-        assertThat(page.getByText("Log Out")).isVisible();
-        assertThat(page.getByText("Welcome, cgaucho@ucsb.edu")).isVisible();
+    assertThat(page.getByText("Log Out")).isVisible();
+    assertThat(page.getByText("Welcome, cgaucho@ucsb.edu")).isVisible();
 
-        page.getByText("Log Out").click();
+    page.getByText("Log Out").click();
 
-        assertThat(page.getByText("Log In")).isVisible();
-        assertThat(page.getByText("Log Out")).not().isVisible();
-    }
+    assertThat(page.getByText("Log In")).isVisible();
+    assertThat(page.getByText("Log Out")).not().isVisible();
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/dining/web/SwaggerWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/dining/web/SwaggerWebIT.java
@@ -1,5 +1,12 @@
 package edu.ucsb.cs156.dining.web;
 
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserContext;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,54 +17,43 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import com.microsoft.playwright.Browser;
-import com.microsoft.playwright.BrowserContext;
-import com.microsoft.playwright.BrowserType;
-import com.microsoft.playwright.Page;
-import com.microsoft.playwright.Playwright;
-import com.microsoft.playwright.options.AriaRole;
-
-import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ActiveProfiles("integration")
 public class SwaggerWebIT {
-    @Value("${app.playwright.headless:true}")
-    private boolean runHeadless;
+  @Value("${app.playwright.headless:true}")
+  private boolean runHeadless;
 
-    @LocalServerPort
-    private int port;
+  @LocalServerPort private int port;
 
-    private Browser browser;
-    private Page page;
+  private Browser browser;
+  private Page page;
 
-    @BeforeEach
-    public void setup() {
-        browser = Playwright.create().chromium().launch(new BrowserType.LaunchOptions().setHeadless(runHeadless));
+  @BeforeEach
+  public void setup() {
+    browser =
+        Playwright.create()
+            .chromium()
+            .launch(new BrowserType.LaunchOptions().setHeadless(runHeadless));
 
-        BrowserContext context = browser.newContext();
-        page = context.newPage();
+    BrowserContext context = browser.newContext();
+    page = context.newPage();
 
-        String url = String.format("http://localhost:%d/swagger-ui/index.html", port);
-        page.navigate(url);
-    }
+    String url = String.format("http://localhost:%d/swagger-ui/index.html", port);
+    page.navigate(url);
+  }
 
-    @AfterEach
-    public void teardown() {
-        browser.close();
-    }
+  @AfterEach
+  public void teardown() {
+    browser.close();
+  }
 
-    @Test
-    public void swagger_page_can_be_loaded() throws Exception {
-        assertThat(page.getByText("Swagger: UCSB CMPSC 156 proj-dining"))
-                .isVisible();
+  @Test
+  public void swagger_page_can_be_loaded() throws Exception {
+    assertThat(page.getByText("Swagger: UCSB CMPSC 156 proj-dining")).isVisible();
 
-        assertThat(page.getByText("Home Page"))
-                .isVisible();
+    assertThat(page.getByText("Home Page")).isVisible();
 
-        assertThat(page.getByText("H2 Console (only on localhost)"))
-                .isVisible();
-    }
-
+    assertThat(page.getByText("H2 Console (only on localhost)")).isVisible();
+  }
 }


### PR DESCRIPTION
Closes #62 

In this PR, we add automatic backend code formatting.

* changed pom.xml to include the needed plugin
* added `.mvn/jvm.config`  (see below)
* added workflow `15-backend-format.yml` to check and update formatting in the backend.

When reviewing, focus on [this commit](https://github.com/ucsb-cs156/proj-dining/pull/74/commits/36cf40bf369ed164dc8c9070b4d8a12642174550) in which *only three file are changed*.

The other changes should all simply be formatting changes. 

This PR also adds a pre-commit hook to do the formatting.

Based on: <https://github.com/ucsb-cs156/proj-frontiers/pull/324> by @Division7 

## What are the changes to `.mvn/jvm.config`

Honestly, we don't know; they were added by user @GlassBricks when they first added this to the proj-courses code base in this commit: <https://github.com/ucsb-cs156/proj-courses/commit/2f910f5c4592d5238e1d8be8863f8cab11c4428e>

We asked Gemini (an AI platform) and here is what Gemini came up with:

### Prompt

(I first pasted in the contents of the change to the pom.xml and the contents of .mvn/jvm.config and noted that these were changes designed to add backend code formatting the project.  I then proceeded with these questions:)

My questions are

1. What does this `.mvn/jvm.config` file do?
2. Can you provide links to documentation where I can learn more about it?
3. Can you suggest why the developer might have added it in a PR to add the code formatter to the project? 

### Gemini Response

#### How it works and what it does
The file, located in the `.mvn` directory at the root of a project, is automatically picked up and used by Maven. It's an alternative to setting the `MAVEN_OPTS` environment variable, which can be inconsistent across different developers' machines. By using this file, all developers get the same JVM configuration applied whenever they execute a Maven command, such as `mvn clean install` or `mvn test`. The specific arguments `--add-exports` in the provided configuration are a part of Java's **module system** introduced in Java 9. They are used to break the encapsulation of a module, making internal packages accessible to other modules. In your case, the `jdk.compiler` module is an internal JDK module, and the `--add-exports` flags are making its `com.sun.tools.javac` packages available to the Maven process. This is often necessary for tools that use internal APIs of the JDK, which are not officially part of the public API.


#### Documentation
* **Official Maven Documentation**: The official Maven documentation on the [Maven JVM Config file](https://maven.apache.org/configure.html#jvm-config-file) provides a brief explanation of how to use this file and its purpose.
* **Oracle Java Documentation**: For more information on the `--add-exports` flag and the Java Platform Module System (JPMS), you can refer to the [Oracle documentation on JPMS](https://docs.oracle.com/en/java/javase/21/migrate/index.html#GUID-7B5AE711-2059-4E90-BE8E-3444B20C6984). It explains how to handle encapsulation issues and the role of `--add-exports` in a modular environment.

#### Why it was added

The developer likely added the `.mvn/jvm.config` file with the `--add-exports` flags to enable the `git-code-format-maven-plugin` to function correctly with modern Java versions (Java 9 and above). The plugin, specifically the `google-java-format` dependency, needs to access the internal `com.sun.tools.javac` APIs from the JDK's compiler to parse and format Java source files.

In Java 9+, these APIs are encapsulated within the `jdk.compiler` module and are not exposed by default. Without the `--add-exports` flags, the plugin would fail with an `InaccessibleObjectException` or similar error because it wouldn't be able to access the necessary classes. The `.mvn/jvm.config` file provides a project-wide solution to this issue, ensuring that the code formatter works for all developers without requiring manual configuration or workarounds.
