### PR TITLE
Update pom.xml and workflows to get more consistency between dining and frontiers

### DIFF
--- a/.github/workflows/02-gh-pages-rebuild-part-1.yml
+++ b/.github/workflows/02-gh-pages-rebuild-part-1.yml
@@ -7,7 +7,6 @@ env:
   # See: https://github.com/actions/setup-java#supported-distributions
   JAVA_DISTRIBUTION: ${{ vars.JAVA_DISTRIBUTION || 'temurin' }} 
 
-
 permissions:
   contents: write
   pages: write
@@ -45,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [initialize]
     env:
-      destination: target/site/apidocs   
+      destination: target/reports/apidocs   
     steps:
     - name: Checkout local code to establish repo
       uses: actions/checkout@v4
@@ -58,7 +57,7 @@ jobs:
          cache-dependency-path: 'pom.xml' 
   
     - name: Build javadoc
-      run: mvn -DskipTests javadoc:javadoc
+      run: mvn -ntp -B -DskipTests javadoc:javadoc
 
     - name: Upload to artifacts
       uses: actions/upload-artifact@v4
@@ -67,6 +66,7 @@ jobs:
           path: ${{ env.destination }}
           overwrite: true
 
+  
   build-chromatic-main:
     name: b - Chromatic (main)
     runs-on: ubuntu-latest
@@ -98,6 +98,7 @@ jobs:
           # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: frontend
+          forceRebuild: true
     - name: Echo output
       run: |
           echo "Chromatic URL: ${{ steps.run_chromatic.outputs.url }}"
@@ -116,7 +117,7 @@ jobs:
           name: chromatic
           path: ${{ env.destination }}
           overwrite: true
-
+  
   build-jacoco-main:
     name: c - Jacoco (main)
     runs-on: ubuntu-latest
@@ -139,7 +140,7 @@ jobs:
       continue-on-error: true
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test jacoco:report verify
+      run: mvn -ntp -B test jacoco:report verify
 
     - name: Upload to artifacts
       uses: actions/upload-artifact@v4
@@ -147,6 +148,7 @@ jobs:
           name: jacoco
           path: ${{ env.destination }}
           overwrite: true
+
 
   build-pitest-main:
     name: d - Pitest (main)
@@ -166,7 +168,6 @@ jobs:
          java-version-file: ./.java-version
          cache: 'maven'
          cache-dependency-path: 'pom.xml' 
-
     - name: create directories
       run: |
          mkdir -p ${{ env.destination }}
@@ -174,7 +175,7 @@ jobs:
 
     - name: Download artifact
       id: download-artifact
-      uses: dawidd6/action-download-artifact@v2.27.0
+      uses: dawidd6/action-download-artifact@v6
       with:
         workflow: 02-gh-pages-rebuild-part-1.yml
         github_token: ${{secrets.GITHUB_TOKEN}}
@@ -196,7 +197,7 @@ jobs:
       continue-on-error: true
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn test pitest:mutationCoverage -DmutationThreshold=100 
+      run: mvn -ntp -B test pitest:mutationCoverage -DmutationThreshold=100 
 
     - name: Upload Pitest History to Artifacts
       if: always() # always upload artifacts, even if tests fail
@@ -206,12 +207,14 @@ jobs:
         path: ${{ env.history_destination}}/history.bin
         overwrite: true
 
+
     - name: Upload to artifacts
       uses: actions/upload-artifact@v4
       with:
           name: pitest
           path: ${{ env.destination }}
           overwrite: true
+
 
   build-coverage-main:
     name: e - Coverage (main)
@@ -274,7 +277,7 @@ jobs:
 
     - name: Download artifact
       id: download-artifact
-      uses: dawidd6/action-download-artifact@v2.27.0
+      uses: dawidd6/action-download-artifact@v6
       with:
         workflow: 02-gh-pages-rebuild-part-1.yml
         github_token: ${{secrets.GITHUB_TOKEN}}
@@ -297,6 +300,7 @@ jobs:
         path: frontend/history
         overwrite: true
 
+
     - name: Upload report to Artifacts
       if: always() # always upload artifacts, even if tests fail
       uses: actions/upload-artifact@v4
@@ -304,6 +308,7 @@ jobs:
         name: stryker
         path: frontend/reports/mutation/mutation.html
         overwrite: true
+
 
   a-build-javadoc-for-each-pr:
     name: a - Javadoc (${{ matrix.value.number }}, ${{ matrix.value.headRefName }})
@@ -313,7 +318,7 @@ jobs:
     needs: [initialize]
 
     env:
-      destination: target/site/apidocs   
+      destination: target/reports/apidocs   
     strategy:
       matrix:
         value: ${{ fromJSON(needs.initialize.outputs.pull_requests)}}
@@ -329,13 +334,13 @@ jobs:
     - name: Set up Java (version from .java-version file)
       uses: actions/setup-java@v4
       with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }} 
-          java-version-file: ./.java-version
-          cache: 'maven'
-          cache-dependency-path: 'pom.xml' 
+         distribution: ${{ env.JAVA_DISTRIBUTION }} 
+         java-version-file: ./.java-version
+         cache: 'maven'
+         cache-dependency-path: 'pom.xml' 
 
     - name: Build javadoc
-      run: mvn -DskipTests javadoc:javadoc
+      run: mvn -ntp -B -DskipTests javadoc:javadoc
  
     - name: Upload javadoc to Artifacts
       if: always() # always upload artifacts, even if tests fail
@@ -344,6 +349,7 @@ jobs:
         name: prs-${{ matrix.value.number }}-javadoc
         path: ${{ env.destination }}
         overwrite: true
+
     
   b-build-chromatic-for-each-pr:
     name: b - Chromatic (${{ matrix.value.number }}, ${{ matrix.value.headRefName }})
@@ -410,7 +416,7 @@ jobs:
           name: prs-${{ matrix.value.number }}-chromatic
           path: ${{ env.destination }}
           overwrite: true
-  
+
   c-build-jacoco-for-each-pr:
     name: c - Jacoco (${{ matrix.value.number }}, ${{ matrix.value.headRefName }})
     runs-on: ubuntu-latest
@@ -433,16 +439,16 @@ jobs:
     - name: Set up Java (version from .java-version file)
       uses: actions/setup-java@v4
       with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }} 
-          java-version-file: ./.java-version
-          cache: 'maven'
-          cache-dependency-path: 'pom.xml' 
+         distribution: ${{ env.JAVA_DISTRIBUTION }} 
+         java-version-file: ./.java-version
+         cache: 'maven'
+         cache-dependency-path: 'pom.xml' 
 
     - name: Build with Maven
       continue-on-error: true
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test jacoco:report verify
+      run: mvn -ntp -B test jacoco:report verify
  
     - name: Upload to artifacts
       uses: actions/upload-artifact@v4
@@ -450,7 +456,8 @@ jobs:
           name: prs-${{ matrix.value.number }}-jacoco
           path: target/site/jacoco
           overwrite: true
- 
+
+
   d-build-pitest-for-each-pr:
     name: d - Pitest (${{ matrix.value.number }}, ${{ matrix.value.headRefName }})
     runs-on: ubuntu-latest
@@ -494,7 +501,7 @@ jobs:
 
     - name: Download artifact
       id: download-artifact
-      uses: dawidd6/action-download-artifact@v2.27.0
+      uses: dawidd6/action-download-artifact@v6
       with:
         workflow: 02-gh-pages-rebuild-part-1.yml
         github_token: ${{secrets.GITHUB_TOKEN}}
@@ -512,7 +519,7 @@ jobs:
       continue-on-error: true
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn test pitest:mutationCoverage -DmutationThreshold=100 
+      run: mvn -ntp -B test pitest:mutationCoverage -DmutationThreshold=100 
   
     - name: Debugging output after mvn pitest ...
       run: |
@@ -526,12 +533,14 @@ jobs:
         path: ${{ env.history_destination}}/history.bin
         overwrite: true
 
+
     - name: Upload to artifacts
       uses: actions/upload-artifact@v4
       with:
           name: prs-${{ matrix.value.number }}-pitest
           path: ${{ env.destination }}
           overwrite: true
+
 
   e-build-coverage-for-each-pr:
     name: e - Coverage (${{ matrix.value.number }}, ${{ matrix.value.headRefName }})
@@ -580,6 +589,7 @@ jobs:
         overwrite: true
 
 
+
   f-build-stryker-for-each-pr:
     timeout-minutes: 60
     name: f - Stryker (${{ matrix.value.number }}, ${{ matrix.value.headRefName }})
@@ -622,7 +632,7 @@ jobs:
 
     - name: Download artifact
       id: download-artifact
-      uses: dawidd6/action-download-artifact@v2.27.0
+      uses: dawidd6/action-download-artifact@v6
       with:
         workflow: 02-gh-pages-rebuild-part-1.yml
         github_token: ${{secrets.GITHUB_TOKEN}}
@@ -642,10 +652,11 @@ jobs:
         name: stryker-incremental-${{ matrix.value.number }}.json
         path: ${{ env.history_destination }}
         overwrite: true
-      
+
     - name: Upload to artifacts
       uses: actions/upload-artifact@v4
       with:
         name: prs-${{ matrix.value.number }}-stryker
         path: ${{ env.destination }}/mutation.html
         overwrite: true
+

--- a/.github/workflows/04-gh-pages-redeploy-part-2.yml
+++ b/.github/workflows/04-gh-pages-redeploy-part-2.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   GH_TOKEN: ${{ github.token }}
-  javadoc_dest: target/site/apidocs
+  javadoc_dest: target/reports/apidocs
   chromatic_dest: frontend/chromatic_static
   jacoco_dest: target/site/jacoco
   pitest_dest: target/pit-reports

--- a/.github/workflows/10-backend-unit.yml
+++ b/.github/workflows/10-backend-unit.yml
@@ -33,5 +33,5 @@ jobs:
     - name: Build with Maven
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test 
+      run: mvn -ntp -B test 
       

--- a/.github/workflows/11-backend-integration.yml
+++ b/.github/workflows/11-backend-integration.yml
@@ -31,5 +31,5 @@ jobs:
          cache-dependency-path: 'pom.xml' 
   
     - name: Run IT tests with maven
-      run: INTEGRATION=true mvn -B test-compile failsafe:integration-test failsafe:verify
+      run: INTEGRATION=true mvn -ntp -B test-compile failsafe:integration-test failsafe:verify
       

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Build with Maven
       env:
         TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test jacoco:report verify
+      run: mvn -ntp -B test jacoco:report verify
 
     - name: Get PR number
       id: get-pr-num

--- a/.github/workflows/13-backend-incremental-pitest.yml
+++ b/.github/workflows/13-backend-incremental-pitest.yml
@@ -44,7 +44,7 @@ jobs:
           echo "branch_name=${BRANCH}" >> "$GITHUB_ENV"    
     - name: Download artifact
       id: download-artifact
-      uses: dawidd6/action-download-artifact@v2.27.0
+      uses: dawidd6/action-download-artifact@v6
       with:
         github_token: ${{secrets.GITHUB_TOKEN}}
         branch: ${{ env.branch_name }}
@@ -59,7 +59,7 @@ jobs:
         [ -f "$historyFile" ] && cp $historyFile target/pit-history/history.bin
 
     - name: Build with Maven
-      run: mvn -B test 
+      run: mvn -ntp -B test 
     - name: Pitest
       run: mvn pitest:mutationCoverage -DmutationThreshold=100 
     - name: Upload Pitest History to Artifacts

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -43,7 +43,7 @@ jobs:
          cache: 'maven'
          cache-dependency-path: 'pom.xml' 
     - name: Build with Maven
-      run: mvn -B test 
+      run: mvn -ntp -B test 
     
     # Note that we DO NOT download history in this job;
     # this job is intended as a "reset" of the history each time the 

--- a/.github/workflows/34-frontend-main-mutation-testing.yml
+++ b/.github/workflows/34-frontend-main-mutation-testing.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 80
 
     steps:
-      - uses: szenius/set-timezone@v1.2
+      - uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "America/Los_Angeles"
       - uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
           mkdir -p frontend/reports
 
       - name: Download artifact
-        uses: dawidd6/action-download-artifact@v2.27.0
+        uses: dawidd6/action-download-artifact@v6
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           branch: main

--- a/.github/workflows/40-check-production-build.yml
+++ b/.github/workflows/40-check-production-build.yml
@@ -28,7 +28,7 @@ jobs:
         timezoneLinux: "America/Los_Angeles"
     - uses: actions/checkout@v4
     - name: Set up Java (version from .java-version file)
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
          distribution: ${{ env.JAVA_DISTRIBUTION }} 
          java-version-file: ./.java-version

--- a/.github/workflows/56-javadoc-main-branch.yml
+++ b/.github/workflows/56-javadoc-main-branch.yml
@@ -36,7 +36,7 @@ jobs:
          cache-dependency-path: 'pom.xml' 
   
     - name: Build javadoc
-      run: mvn -DskipTests javadoc:javadoc
+      run: mvn  -ntp -B -DskipTests javadoc:javadoc
 
     - name: Deploy 🚀    
       if: always() # always upload artifacts, even if tests fail
@@ -47,6 +47,6 @@ jobs:
         attempt_delay: 5000
         with: |
           branch: gh-pages # The branch the action should deploy to.
-          folder: target/site/apidocs # The folder where the javadoc files are located
+          folder: target/reports/apidocs # The folder where the javadoc files are located
           clean: true # Automatically remove deleted files from the deploy branch
           target-folder: javadoc # The folder that we serve our javadoc files from

--- a/.github/workflows/58-javadoc-pr.yml
+++ b/.github/workflows/58-javadoc-pr.yml
@@ -72,7 +72,7 @@ jobs:
         token: ${{ github.token }}
 
     - name: Set up Java (version from .java-version file)
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
          distribution: ${{ env.JAVA_DISTRIBUTION }} 
          java-version-file: ./.java-version
@@ -80,7 +80,7 @@ jobs:
          cache-dependency-path: 'pom.xml' 
   
     - name: Build javadoc
-      run: mvn -DskipTests javadoc:javadoc
+      run: mvn  -ntp -B -DskipTests javadoc:javadoc
  
     - name: Deploy 🚀
       if: always() # always upload artifacts, even if tests fail
@@ -91,6 +91,6 @@ jobs:
         attempt_delay: 5000
         with: |
           branch: gh-pages # The branch the action should deploy to.
-          folder: target/site/apidocs # The folder where mvn javadoc:javadoc outputs the javadoc files
+          folder: target/reports/apidocs # The folder where mvn javadoc:javadoc outputs the javadoc files
           clean: true # Automatically remove deleted files from the deploy branch
           target-folder: prs/${{ needs.get-pr-num.outputs.pr_number }}/javadoc # The folder that we serve our javadoc files from 

--- a/.github/workflows/98-copy-issue-by-number.yml
+++ b/.github/workflows/98-copy-issue-by-number.yml
@@ -43,7 +43,7 @@ jobs:
     needs: [initialize]
 
     env:
-      destination: target/site/apidocs  
+      destination: target/reports/apidocs  
     strategy:
       matrix:
         value: ${{ fromJSON(needs.initialize.outputs.issues)}}

--- a/.github/workflows/99-copy-issues.yml
+++ b/.github/workflows/99-copy-issues.yml
@@ -38,7 +38,7 @@ jobs:
     needs: [initialize]
 
     env:
-      destination: target/site/apidocs  
+      destination: target/reports/apidocs  
     strategy:
       matrix:
         value: ${{ fromJSON(needs.initialize.outputs.ISSUES)}}

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.5</version>
+    <version>3.4.3</version>
   </parent>
 
   <!-- (2) <groupId/> -->


### PR DESCRIPTION
In this PR, we update the pom.xml to a later version of the Spring Boot starter to match proj-frontiers.

We also update small details in the workflows so that they are more consistent between proj-dining and proj-frontiers.

* We add -ntp and -B to many maven steps
* We fix the path for javadoc generation to match later versions (/target/reports/apidocs not /target/site/apidocs)
* We make all steps that install Java use the same environment variable so that it's easier to update in one place (including in one place for a repo or organization)