### PR TITLE
pc - update prod value of show swagger to false

### DIFF
--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -3,4 +3,4 @@ spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 
 # True for practice apps; should be off for real production apps
-app.showSwaggerUILink=true
+app.showSwaggerUILink=false


### PR DESCRIPTION
On Prod, we don't want to show the swagger link.   

It is still accessible for people that know the URL, which is fine; the endpoints should all be protected, and don't expose any functionality that we don't want users to have.

But we don't want to confuse end users with a weird menu option.

Before:


After: 