### PR TITLE
Bump lib-jobs to v0.2.0: job_logs table, /paginated filtering, log tailing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
     <dependency>
       <groupId>com.github.ucsb-cs156</groupId>
       <artifactId>lib-jobs</artifactId>
-      <version>v0.1.1</version>
+      <version>v0.2.0</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
## Summary
- Bumps `lib-jobs` from v0.1.1 to v0.2.0. Dining is the pilot app for this release, chosen because it has no real users yet and no historical job-log data to backfill (see [lib-jobs DESIGN.md §8](https://github.com/ucsb-cs156/lib-jobs/blob/main/docs/DESIGN.md)).
- v0.2.0 replaces the single `jobs.log` TEXT column with a normalized `job_logs` table (one row per log line), eliminating an O(N²) read-modify-write and a status-clobbering bug the old design enabled.
- The new `job_logs` table ships as a Liquibase changeset inside the library jar's own bundled changelog, which this app already includes wholesale — **no app-level Liquibase changeset or code change is needed here beyond the version bump.**
- `/api/jobs/paginated` gains optional filter query params (`status`, `jobName`, `createdByEmail`, `scopeType`, `scopeId`) and a widened sort allowlist; a new `GET /api/jobs/logs/{id}/tail?afterId=` endpoint supports incremental live-tailing of a running job's log. Dining has no frontend jobs UI yet, so these are being validated via a live dokku smoke test rather than a frontend change.

## Test plan
- [x] `mvn test` — all tests pass, `job_logs` changeset applies cleanly against H2 (`ddl-auto=validate`)
- [x] `mvn verify` — jacoco 100%
- [x] `mvn org.pitest:pitest-maven:mutationCoverage` — 217/217 mutations killed
- [x] Verified `com.github.ucsb-cs156:lib-jobs:v0.2.0` resolves from JitPack on a cold `~/.m2` cache
- [ ] CI green
- [ ] Live dokku smoke test: launch a test job, confirm `/api/jobs/all`, `/api/jobs/logs/{id}`, and `/api/jobs/logs/{id}/tail` all behave correctly against Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)